### PR TITLE
[BOJ] [Stack] [3307] [대회가 끝나고 난 뒤 빰빠빰] 

### DIFF
--- a/BOJ/Stack/3307/calisyj/balloons.py
+++ b/BOJ/Stack/3307/calisyj/balloons.py
@@ -1,0 +1,17 @@
+'''
+Baekjopn : 대회가 끝나고 난 뒤 빰빠빰
+'''
+n  = int(input()) 
+location_radius_list = [tuple(map(int, input().split())) for _ in range(n)]  
+stk = []
+
+for xj, yj in location_radius_list: 
+  while stk:                           
+    xi, yi = stk[-1]
+    yj = min(yj, (xj-xi)**2 / (4*yi))
+    if yj >= yi: stk.pop()
+    else: break
+  stk.append((xj, yj))
+  print("%.3f" % yj)
+  
+


### PR DESCRIPTION
Source URL : https://www.acmicpc.net/problem/3307

문제 요구사항 : 풍선을 모두 부풀리기 위해서 공기가 얼마나 필요한지 알고 싶다. 각 풍선들의 최종 반지름을 구하라.

입력값
첫 번째 줄에 풍선의 개수 n이 주어진다 (1 ≤ n ≤ 200,000).  이어지는 n개의 줄에는 풍선에 대한 정보가 주어진다. 

각 i번째 줄에는 xi와  ri 두 개의 정수가 주어진다. (풍선이 놓여 있는 x축 좌표 0 ≤ xi ≤ 10**9,  풍선의 반지름의 최댓값 1 ≤ ri ≤ 10**9). 각 풍선들의 위치인 x좌표는 반드시 오른쪽으로만 나아간다.

출력값
결과값은 반드시 n개의 줄로 출력되어야 하며, i번째 줄에는 정확히 i번째 풍선의 최종 반지름만 출력되어야 한다. 소수점 3번째 자리까지만 출력 한다.

접근 방법 :  
Stack을 통해 필요 없는 것 추가, 삭제

필요 없는 대상 책정
->  i번째 풍선의 반지름yi가 yi<yj (i>j)인 경우 i번째 풍선은 j번째 풍선에 아무런 영향을 주지 않는다.  
 이럴 경우 i번째 풍선은 필요가 없으므로 stack에서 삭제한다.
 
기본 가정
-> j번째 이후의 풍선들은 i번째 풍선에 닿기 전에 j번째 풍선에 닿는다.



풀이 순서 : 
1) Stack에 첫 번째 풍선의 좌표, 반지름을 추가                                  
2) 그 다음 풍선의 좌표,반지름의 min(yi, (xj-xi)**2/(4*yj))과 비교
3) 첫 번째 풍선의 반지름보다 반지름이 작은 경우의 풍선 삭제(pop).
4) 아닌 경우 stack에 추가(append)후 추가된 풍선을 기준으로 다음 비교 수행


문제 풀이 결과 :  성공


