### PR TITLE
[BOJ] [SegmentTree] [11505] [구간 곱 구하기]

### DIFF
--- a/BOJ/SegmentTree/11505/Blanc_et_Noir/Main.java
+++ b/BOJ/SegmentTree/11505/Blanc_et_Noir/Main.java
@@ -1,0 +1,89 @@
+//https://www.acmicpc.net/problem/11505
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Main {
+	public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	public static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	public static long[] tree = new long[3000001];
+	public static long[] arr = new long[1000000];
+	
+	//구간곱은 long이 표현할 수 있는 범위를 넘어서므로 매번 모듈로 연산하여 나머지를 저장함
+	public static final long mod = 1000000007;
+	
+	public static void init(int node, int start, int end) {
+		//리프노드라면 해당 값을 트리에 추가
+		if(start==end) {
+			tree[node] = arr[start];
+		}else {
+			//리프노드가 아니라면 왼쪽 자식과 오른쪽 자식에 대해 재귀적으로 메소드 호출
+			init(node*2,start,(start+end)/2);
+			init(node*2+1,(start+end)/2+1,end);
+			//왼쪽 자식과 오른쪽 자식의 값을 곱하여 자신의 값으로 사용
+			tree[node] = ((tree[node*2]%mod)*(tree[node*2+1]%mod))%mod;
+		}
+	}
+	
+	public static long query(int node, int start, int end, long left, long right) {
+		//탐색 범위를 벗어나서 겹치는 영역이 전혀 없으면 종료
+		//1은 리턴하더라도 구간 곱에 영향을 미치지 않으므로 적당한 값
+		if(left>end||right<start) {
+			return 1;
+		}
+		//탐색하는 범위가 해당 구간을 완전히 포함하면 탐색 종료후 리턴
+		if(left<=start && right>=end) {
+			return tree[node];
+		}
+		//왼쪽 자식과 오른쪽 자식의 결과를 곱하여 자신의 결과로 사용
+		return ((query(node*2, start, (start+end)/2, left, right)%mod) * (query(node*2+1, (start+end)/2+1, end, left, right)%mod))%mod;
+	}
+	
+	public static void update(int node, int start, int end, int index, long val) {
+		//인덱스가 범위를 벗어나면 종료
+		if(index>end||index<start) {
+			return;
+		}
+		//리프노드라면 그 노드를 해당 값으로 변경, 트리의 값도 변경
+		if(start==end) {
+			arr[index] = val;
+			tree[node] = val;
+			return;
+		}
+		//왼쪽 자식과 오른쪽 자식에 대해서도 재귀적으로 메소드 호출
+		update(node*2,start,(start+end)/2,index,val);
+		update(node*2+1,(start+end)/2+1,end,index,val);
+		//자신의 값은 변경된 자식들의 곱으로 설정함
+		tree[node] = ((tree[node*2]%mod)*(tree[node*2+1]%mod))%mod;
+	}
+	
+	public static void main(String[] args) throws Exception{
+
+		String[] temp = br.readLine().split(" ");
+		int N = Integer.parseInt(temp[0]);
+		int M = Integer.parseInt(temp[1]);
+		int K = Integer.parseInt(temp[2]);
+		
+		for(int i=0; i<N;i++) {
+			arr[i]=Long.parseLong(br.readLine());
+		}
+		
+		init(1,0,N-1);
+		
+		for(int j=0;j<M+K;j++) {
+			temp = br.readLine().split(" ");
+			int A = Integer.parseInt(temp[0]);
+			int B = Integer.parseInt(temp[1]);
+			long C = Long.parseLong(temp[2]);
+			
+			if(A==1) {
+				update(1,0,N-1,B-1,C);
+			}else {
+				bw.write((query(1,0,N-1,B-1,C-1)%mod)+"\n");
+			}
+		}
+		bw.flush();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/11505)


문제 요구사항 : 주어진 배열에 대해 다양한 구간에서의 곱을 구하는 문제로, 세그먼트 트리에 대한 이해야 필요.
그러나, 중요한 것은 주어진 배열 그대로가 아니라, 배열의 특정 위치의 값을 다른 값으로 변경하는 연산도 필요.

접근 방법 : 기존 세그먼트 트리를 이용한 문제와 같이, 세그먼트 트리를 생성하고, 초기화하고, 적절히 쿼리를 수행하면 됨.
구간 곱의 경우 탐색하는 범위가 탐색하고자 하는 범위를 벗어난 경우 1을 리턴함으로써 재귀적으로 부모 노드에 값을
할당할 때 1을 곱하여도 아무런 변화가 없게끔 하는 것이 중요함.

update( )의 경우 변경하고자 하는 인덱스가 start, end값을 벗어난 경우 그대로 종료, 안에 포함되는 경우 탐색 진행을
함으로써 리프노드에 도달, 해당 인덱스의 값을 val로 변경, 부모노드 또한 자식노드들의 변경으로 인한 변경점을
고려해야함. 이때 mod 연산을 반드시 해야 overflow를 방지할 수 있음.


풀이 순서 : 먼저 세그먼트 트리를 초기화하고, 입력값이 1이면 update( ), 2라면 query( )를 수행함.
세그먼트트리의 크기는 넉넉히 300001로 잡고, 기존의 문제들과는 다르게 update( ) 메소드의 구현이 필요함.
update( )의 동작은 query( )와 유사하지만, start와 end가 left, right 사이에 있거나 걸치는 것과 다르게
index가 start, end 사이에 있어야 탐색을 계속 하도록 해야함.


문제 풀이 결과 : 성공