### PR TITLE
[BOJ] [SegmentTree] [2268] [수들의 합 7]

### DIFF
--- a/BOJ/SegmentTree/2268/Blanc_et_Noir/Main.java
+++ b/BOJ/SegmentTree/2268/Blanc_et_Noir/Main.java
@@ -1,0 +1,68 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Main {
+	public static long[] tree = new long[3000000];
+	public static long[] arr;
+	public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	public static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	
+	public static long query(int node, int start, int end, int left, int right) {
+		//탐색하고자 하는 범위가 노드의 구간을 완전히 벗어나면 0을 리턴
+		//0은 합계에 추가하여도 변화가 없음
+		if(left>end||right<start) {
+			return 0;
+		}
+		//탐색하고자 하는 범위가 노드의 구간을 완전히 포함하므로 그 값을 리턴
+		if(left<=start&&right>=end) {
+			return tree[node];
+		}
+		//왼쪽, 오른쪽 자식에 대해 수행한 쿼리의 합을 리턴
+		return query(node*2,start,(start+end)/2,left,right)+query(node*2+1,(start+end)/2+1,end,left,right);
+	}
+	
+	public static void update(int node, int index, int start, int end, long val) {
+		//인덱스가 구간의 범위를 벗어나면 종료
+		if(index<start||index>end) {
+			return;
+		}
+		//리프노드라면 그 값을 val로 변경
+		if(start==end) {
+			tree[node]=val;
+			return;
+		}
+		//왼쪽, 오른쪽 자식에 대해 메소드를 재귀 호출
+		update(node*2,index,start,(start+end)/2,val);
+		update(node*2+1,index,(start+end)/2+1,end,val);
+		
+		//부모 노드의 값을 자식 노드들의 값의 합으로 갱신
+		tree[node] = tree[node*2]+tree[node*2+1];
+	}
+	
+	public static void main(String[] args) throws Exception{
+		String[] temp = br.readLine().split(" ");
+		int N = Integer.parseInt(temp[0]);
+		int M = Integer.parseInt(temp[1]);
+		
+		for(int i=0;i<M;i++) {
+			temp = br.readLine().split(" ");
+			long I = Long.parseLong(temp[0]);
+			long J = Long.parseLong(temp[1]);
+			long K = Long.parseLong(temp[2]);
+
+			if(I==0) {
+				if(J>K) {
+					long num = J;
+					J = K;
+					K = num;
+				}
+				bw.write(query(1,0,N-1,(int)J-1,(int)K-1)+"\n");
+			}else {
+				update(1,(int)J-1,0,N-1,K);
+			}
+		}
+		bw.flush();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/2268)


문제 요구사항 : https://www.acmicpc.net/problem/2042 문제와 동일한 유형의 문제로
세그먼트트리를 구현하고 활용할 줄 아는 것이 필요함.


접근 방법 : 세그먼트 트리의 init( )을 구현하지 않음. 왜냐하면 초기의 배열의 요소는 모두 0임을 문제에서 제시함.
그외에는 query( ), update( )메소드의 동작은 모두 BOJ 2042번 문제와 동일함.

풀이 순서 : 굳이 세그먼트 트리를 초기화할 필요는 없으며, query( )의 동작은 탐색하고있는 구간이
탐색하고자 하는 구간을 완전히 포함하는 경우, 완전히 벗어나는 경우, 조금 걸치는 경우 세가지로 구분하여
적절하게 처리를 수행함. 중요한 것은 완전히 구간이 겹치지 않는 경우에는 0을 리턴함으로써
더하더라도 부모노드에는 영향이 없도록 해야함.

update( )의경우, query( )와는 다르게 탐색하는 구간이 탐색하고자 하는 구간과 겹치는지 아닌지를 보는 것이 아니라
탐색하고있는 구간이 특정 인덱스를 포함하고 있는지 아닌지에 따라 처리가 달라진다는 점에 유의해야함.


문제 풀이 결과 : 성공