### PR TITLE
[BOJ] [Dijkstra] [1238] [파티] 

### DIFF
--- a/BOJ/Dijkstra/1238/Blanc_et_Noir/Main.java
+++ b/BOJ/Dijkstra/1238/Blanc_et_Noir/Main.java
@@ -1,0 +1,117 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+//해당 인덱스까지 오는데 소요한 비용을 저장하는 노드 클래스
+class Node{
+	int index, dist;
+	Node(int index, int dist){
+		this.index = index;
+		this.dist = dist;
+	}
+}
+
+public class Main {
+	public static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	public static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	public static final int INF = Integer.MAX_VALUE;
+	public static int N,M,X;
+	public static ArrayList<ArrayList<Node>> graph = new ArrayList<ArrayList<Node>>();
+	
+	public static int dijkstra(int s, int e) {
+		int[] d;
+		
+		//우선순위큐중에서도 힙을 사용하여야함
+		//비용이 가장 적은 노드가 우선적으로 반환됨
+		PriorityQueue<Node> pq = new PriorityQueue<Node>(new Comparator<Node>() {
+			@Override
+			public int compare(Node o1, Node o2) {
+				if(o1.dist<o2.dist) {
+					return -1;
+				}else if(o1.dist>o2.dist) {
+					return 1;
+				}else {
+					return 0;
+				}
+			}
+		});
+		
+		//최단거리 비용 정보를 저장할 배열
+		d = new int[N];
+		
+		//최단거리 비용 정보를 저장할 배열을 모두 INF값으로 채움
+		Arrays.fill(d, INF);
+		
+		//시작하는 위치는 비용이 0이 되도록 설정후 우선순위큐에 추가함
+		d[s] = 0;
+		pq.add(new Node(s,0));
+		
+		while(!pq.isEmpty()) {
+			Node n = pq.poll();
+			int now = n.index;
+			
+			//해당 인덱스까지 오는데 소요된 비용이 최단 비용을 넘어서면 더이상 탐색할 필요 없음
+			//이때, 굳이 방문처리를 하지않아도 되는 장점이 있음
+			if(d[now]<n.dist) {
+				continue;
+			}
+			
+			//인접한노드에 대하여 탐색을 실시함
+			for(int i=0; i<graph.get(now).size(); i++) {
+				int next = graph.get(now).get(i).index;
+				
+				//현재 인덱스까지 오는데 필요한 최단 비용 + 그 인덱스에서 인접한 위치로 이동할때 필요한 비용을 계산함
+				int cost = d[now] + graph.get(now).get(i).dist;
+				
+				//만약 앞서 계산한 비용이, 인접한 노드로 이동할때의 최단비용보다 적다면
+				if(cost < d[next]) {
+					//최단비용을 앞서 계산한 cost로 변경하고, 인접노드에서 다시 탐색을 수행하도록 우선순위큐에 추가함
+					d[next] = cost;
+					pq.add(new Node(next,cost));
+				}
+			}
+		}
+		//최단비용을 반환함
+		return d[e];
+	}
+	
+	public static void main(String[] args) throws Exception{
+		int max = Integer.MIN_VALUE;
+		String[] str = br.readLine().split(" ");
+		N = Integer.parseInt(str[0]);
+		M = Integer.parseInt(str[1]);
+		X = Integer.parseInt(str[2])-1;
+
+		//N개의 정점이 존재하므로 N개의 리스트를 저장해야함
+		for(int i=0; i<N; i++) {
+			graph.add(new ArrayList<Node>());
+		}
+		
+		//간선정보를 그래프에 추가함
+		for(int i=0; i<M; i++) {
+			str = br.readLine().split(" ");
+			int A = Integer.parseInt(str[0])-1;
+			int B = Integer.parseInt(str[1])-1;
+			int T = Integer.parseInt(str[2]);
+			graph.get(A).add(new Node(B,T));
+		}
+		
+		//i에서 X로 갔다가, X에서 i로 오는 비용을 계산함
+		//단방향 그래프이므로 단순히 i에서 X로 가는 비용을 2배하여서는 구할 수 없음
+		for(int i=0; i<N; i++) {
+			int r = dijkstra(i,X)+dijkstra(X,i);
+			if(r>max) {
+				max = r;
+			}
+		}
+		
+		//가장 오랜 시간이 걸리는 사람의 시간을 출력함
+		bw.write(max+"\n");
+		bw.flush();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/1238)


문제 요구사항 : 다익스트라 알고리즘을 구현하되, 우선순위큐를 이용하여 계산할 수 있는지를 묻는 문제임.


접근 방법 : 다익스트라 알고리즘을 구현할때에는 여러가지 방법이 존재하나, 우선순위큐를 이용한 방식이 시간복잡도상 단순한 중첩반복문보다 뛰어나므로, 해당 방식을 선택함.

이때, 우선순위큐는 반드시 비용정보를 토대로 경로 비용이 가장 적은 노드가 먼저 반환되도록 하는, 최소 힙을 사용해야함.

풀이 순서 : 

1. 간선정보를 저장할 그래프를 배열 대신 2차원 ArrayList로 선언후, 간선정보 저장.
    중요한 것은 2차원 인덱스는 시작, 1차원 인덱스는 끝 정점을 가리켜야함.

2. 간선정보 저장후  시작노드에 대한 최단비용을 제외한 모든 비용을 INF로 설정하고
    시작노드부터 탐색을 실시함.

3. 우선순위큐에서 꺼낸 노드의 비용이 해당 인덱스로 가기위한 최단비용보다 크다면
    굳이 더는 탐색할 필요가 없음.

4. 아니라면 현재 위치까지 필요한 최단 비용 + 인접한 노드로 이동하는데 필요한 비용이
    해당 인접한 노드로 이동하는데 필요한 최단비용보다 작을때 해당 비용으로
    최단 비용을 업데이트함

문제 풀이 결과 : 성공

