### PR TITLE
[PGS] [DFS] [네트워크]

### DIFF
--- a/PGS/DFS/네트워크/Blanc_et_Noir/Solution.java
+++ b/PGS/DFS/네트워크/Blanc_et_Noir/Solution.java
@@ -1,0 +1,32 @@
+class Solution {
+    //s노드부터 연결되어있는 노드로 DFS탐색을 실시
+    public static void DFS(int[][] computers, boolean[] v, int s){
+        //자기자신을 방문으로 표시
+        v[s] = true;
+        
+        //자기자신은 이미 방문처리 되어있으므로 별다른 처리 X
+        for(int i=0; i<computers.length; i++){
+            //인접한 노드가 아직 방문하지 않은 노드라면 해당 노드부터 DFS탐색 실시
+            if(!v[i]&&computers[s][i]==1){
+                DFS(computers, v, i);
+            }
+        }
+    }
+    
+    public int solution(int n, int[][] computers) {
+        int answer = 0;
+        
+        //각 노드의 방문 여부를 표시할 배열
+        boolean[] v = new boolean[n];
+        
+        for(int i=0; i<n; i++){
+            //DFS탐색 이후에도 아직 방문하지 않은 노드들에 대해서 DFS탐색 실시
+            if(!v[i]){
+                DFS(computers, v, i);
+                answer++;
+            }
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://programmers.co.kr/learn/courses/30/lessons/43162)


문제 요구사항 : 기본적인 DFS 탐색에 대한 이해가 있는지를 묻는 문제임.


접근 방법 : DFS탐색시, 방문하지않은 인접한 노드로 계속해서 재귀적으로 탐색을 실시하면 됨.
이때, 반드시 방문처리를 적절히 해야하며, DFS탐색의 시작점이 매번 달라지는데,
이 시작점은 반드시 기존에 DFS탐색을 하면서 방문한 적이 없었던 노드여야 함.


풀이 순서 :
1. 방문배열을 1차원 배열로 선언.
2. 자신을 방문처리하고, 인접한 노드이면서 방문하지 않은 노드에 대해 재귀적으로 탐색함.
3. DFS탐색이 한 번 종료되고 남은 노드중 방문하지 않은 노드가 있다면 새로운 네트워크임.


문제 풀이 결과 : 성공

