### PR TITLE
[BOJ] [DP] [1904] [01타일]

### DIFF
--- a/BOJ/DP/1904/inseonyun/main.cpp
+++ b/BOJ/DP/1904/inseonyun/main.cpp
@@ -1,0 +1,41 @@
+
+//////////////////////////////////////////////////
+// BAEKJOON_1904번 : 01타일
+//////////////////////////////////////////////////
+
+#include <iostream>
+
+using namespace std;
+
+int N;
+int* dp;
+void input() {
+	cin >> N;
+
+	dp = new int[N + 1];
+}
+
+void solution() {
+	dp[1] = 1 % 15746;
+	dp[2] = 2 % 15746;
+
+	for (int i = 3; i <= N; i++) {
+		dp[i] = (dp[i - 2] + dp[i - 1]) % 15746;	
+	}
+}
+
+void output() {
+	cout << dp[N];
+}
+
+int main() {
+	ios::sync_with_stdio(false);
+	cin.tie(0);
+	cout.tie(0);
+
+	input();
+	solution();
+	output();
+
+	return 0;
+}


### PR DESCRIPTION
Source URL : https://www.acmicpc.net/problem/1904


문제 요구사항 : 
+ 지원이에게 2진 수열을 가르쳐 주기 위해, 지원이 아버지는 그에게 타일들을 선물해주셨다. 그리고 이 각각의 타일들은 0 또는 1이 쓰여 있는 낱장의 타일들이다.
+ 어느 날 짓궂은 동주가 지원이의 공부를 방해하기 위해 0이 쓰여진 낱장의 타일들을 붙여서 한 쌍으로 이루어진 00 타일들을 만들었다. 결국 현재 1 하나만으로 이루어진 타일 또는 0타일을 두 개 붙인 한 쌍의 00타일들만이 남게 되었다.
+ 그러므로 지원이는 타일로 더 이상 크기가 N인 모든 2진 수열을 만들 수 없게 되었다. 예를 들어, N=1일 때 1만 만들 수 있고, N=2일 때는 00, 11을 만들 수 있다. (01, 10은 만들 수 없게 되었다.) 또한 N=4일 때는 0011, 0000, 1001, 1100, 1111 등 총 5개의 2진 수열을 만들 수 있다.
+ 우리의 목표는 N이 주어졌을 때 지원이가 만들 수 있는 모든 가짓수를 세는 것이다. 단 타일들은 무한히 많은 것으로 가정하자.
+ 첫 번째 줄에 자연수 N이 주어진다. (1 ≤ N ≤ 1,000,000)
+ 첫 번째 줄에 지원이가 만들 수 있는 길이가 N인 모든 2진 수열의 개수를 15746으로 나눈 나머지를 출력한다.


접근 방법 : 
+ N의 값이 1일 때, 2일 때를 참고로 점화식을 세운다. 피보나치의 개념과 비슷하다.


풀이 순서 : 
1. N을 입력받는다.
2. dp 배열을 N + 1만큼 정의한다.
3. 정의한 점화식대로 dp[1] = 1, dp[2] = 2를 대입하고, 그 이후 부터는 dp[ i - 2] + dp [ i - 1] 의 값을 15746으로 나눈 나머지 값을 대입한다.
4. dp[N]의 값을 출력한다.


문제 풀이 결과 : 

![image](https://user-images.githubusercontent.com/84364741/180461760-5a97e9e0-a665-4a5d-83cd-e3f880205bac.png)
