### PR TITLE
[PGS] [Queue] [두 큐 합 같게 만들기]

### DIFF
--- a/PGS/Queue/두-큐-합-같게-만들기/Blanc_et_Noir/Solution.java
+++ b/PGS/Queue/두-큐-합-같게-만들기/Blanc_et_Noir/Solution.java
@@ -1,0 +1,54 @@
+//https://school.programmers.co.kr/learn/courses/30/lessons/118667
+
+import java.util.*;
+
+class Solution {
+    public int solution(int[] queue1, int[] queue2) {
+        long answer = -1;
+        long sum1 = 0, sum2 = 0;
+        
+        Queue<Integer> q1 = new LinkedList<Integer>();
+        Queue<Integer> q2 = new LinkedList<Integer>();
+        
+        //두 개의 큐 각각의 합을 구하고, 배열을 큐로 변환함
+        for(int i=0; i<queue1.length; i++){
+            sum1 += queue1[i];
+            sum2 += queue2[i];
+            
+            q1.add(queue1[i]);
+            q2.add(queue2[i]);
+        }
+
+        //추출 횟수를 기록하는 변수
+        int cnt = 0;
+        
+        //두 큐의 합이 같지 않으면
+        while(sum1 != sum2){
+        	//만약 1번 큐의 합이 더 크다면
+            if(sum1 > sum2){
+            	//1번 큐의 원소 하나를 빼내어 2번 큐에 삽입함
+            	//또한 각각의 큐의 합을 갱신함
+                sum1 -= q1.peek();
+                sum2 += q1.peek();
+                q2.add(q1.poll());
+                cnt++;
+            //만약 2번 큐의 합이 더 크다면
+            }else if(sum1 < sum2){
+            	//2번 큐의 원소 하나를 빼내어 1번 큐에 삽입함
+            	//또한 각각의 큐의 합을 갱신함
+                sum2 -= q2.peek();
+                sum1 += q2.peek();
+                q1.add(q2.poll());
+                cnt++;
+            }
+            
+            //만약 1번 큐와 2번 큐를 모두 순회하였음에도 두 큐의 합이 같지 않다면
+            //절대로 두 큐의 합을 같게 만들 수 없다는 의미이므로 -1을 리턴함
+            if(cnt>queue1.length+queue2.length+2){
+                return -1;
+            }
+        }
+        
+        return cnt;
+    }
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://school.programmers.co.kr/learn/courses/30/lessons/118667)


문제 요구사항 : 

<pre>
해당 문제는 큐 자료구조의 특성을 알고 있는지
두 배열의 원소들의 합을 같게 만들기 위해서 어떤식으로 반복문을
구성해야 하는지를 알고 있는지 묻는 문제임
</pre>

접근 방법 : 

<pre>
큐 자료구조는 맨 앞의 원소를 꺼내어 맨 뒤에 추가하는 FIFO의 특성을 가지므로
각 원소들의 앞, 뒤 순서 자체는 변하지 않게 됨

따라서 현재 두 큐의 합이 같지 않다면, 더 큰 합을 갖는 큐에서 원소를 꺼내어
합이 더 작은 큐에 추가하여 두 큐의 합이 같아지도록 계속 반복하여
문제를 해결할 수 있음
</pre>

풀이 순서 : 

<pre>
1. 두 큐의 각각의 합을 구함

2. 합이 더 큰 큐에서 원소를 하나 꺼내어 합이 더 작은 큐에 원소를 추가하는 것을 반복함

3. 합이 같아지거나, 두 큐의 길이 이상으로 반복되는 경우에 반복을 종료함
</pre>

문제 풀이 결과 : 성공

