### PR TITLE
[PGS] [DFS] [피로도]

### DIFF
--- a/PGS/DFS/피로도/Blanc_et_Noir/Solution.java
+++ b/PGS/DFS/피로도/Blanc_et_Noir/Solution.java
@@ -1,0 +1,34 @@
+class Solution {
+    public static int max;
+    
+    //DFS탐색을 통해 완전탐색을 실시하는 메소드
+    public static void DFS(int[][] dungeons, boolean[] v, int stamina, int cnt){
+    	//만약 던전에 입장한 횟수가 기존 최대치보다 크면
+        if(cnt>max){
+        	//그것을 최대치로 갱신함
+            max = cnt;
+        }
+        //모든 던전에 대하여 탐색실시
+        for(int i=0; i<dungeons.length; i++){
+        	//만약 방문하지 않았던 던전이라면
+            if(!v[i]){
+            	//현재 피로도가 던전 입장에 필요한 최소 피로도보다 많은 경우
+                if(stamina >= dungeons[i][0]){
+                	//해당 던전에 입장한 것으로 처리하고 다시 DFS탐색 수행
+                	v[i] = true;
+                    DFS(dungeons,v,stamina-dungeons[i][1],cnt+1);
+                    
+                    //DFS 종료시에 마치 해당 던전을 방문하지 않았던 것처럼 처리해야함
+                    v[i] = false;
+                }
+            }
+        }
+    }
+    
+    public int solution(int k, int[][] dungeons) {
+        int answer = -1;
+        max = 0;
+        DFS(dungeons, new boolean[dungeons.length],k,0);
+        return max;
+    }
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://school.programmers.co.kr/learn/courses/30/lessons/87946)


문제 요구사항 : 

<pre>
해당 문제는 완전탐색을 DFS로 구현하는 방법을 알고 있는지 묻는 문제임
</pre>

접근 방법 : 

<pre>
완전탐색을 수행할 때엔 DFS, BFS 두 알고리즘을 모두 사용할 수 있겠지만
보통 가장 최단, 최소 등의 값을 구하는, 어떤 결과가 나왔을 때 그 즉시 반복을 종료해야 할 때에는 BFS를,
최장, 최대 등의 값을 구할 때엔 모든 경우의 수를 다 따져볼 수 있도록 DFS를 사용하는 경우가 일반적이며
해당 문제는 "가장 많이 던전을 탐색하는 횟수"를 구하는 것이므로 DFS를 적용하는 것이 좋음.
</pre>

풀이 순서 : 

<pre>
1. DFS 탐색을 수행하되, 해당 던전에 입장하기전 최소 피로도와 현재 잔여 피로도를 비교하여
   던전에 진입할 것인지, 말 것인지를 결정해야함.

2. 던전에 입장하기로 결정했다면, 방문체크를 한 이후에, DFS종료시
   다시 방문하지 않은 것으로 체크해야만 다음 회차의 for문에서 해당 던전에 입장할지 말지를
   다시 결정할 수 있음.

3. 던전에 입장한 횟수가 기존에 기록해두었던 수보다 더 크다면 그것을 최대 횟수로 갱신함
</pre>

문제 풀이 결과 : 

