### PR TITLE
[BOJ] [BFS] [1175] [배달]

### DIFF
--- a/BOJ/BFS/1175/Blanc_et_Noir/Solution.java
+++ b/BOJ/BFS/1175/Blanc_et_Noir/Solution.java
@@ -1,0 +1,117 @@
+//https://www.acmicpc.net/problem/1175
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Queue;
+
+class Node{
+	//각각 y, x좌표, 노드의 방향, 이동 횟수, 배달 상태를 나타냄
+	//p의 경우 배달상태를 나타내며, 비트마스킹을 활용함
+	
+	//예를들어 p의 값이 3이라면 2진 비트로는 11(2) 이므로
+	//C1, C0 두 개의 소포 모두 배달에 성공한 상태인 것임
+	
+	//만약 p값이 2라면 2진비트로는 10(2) 이므로
+	//C1만 배달에 성공했고, C0는 아직 배달이 완료되지 않은 것임
+	int y, x, d, c, p;
+	Node(int y, int x, int d, int c, int p){
+		this.y = y;
+		this.x = x;
+		this.d = d;
+		this.c = c;
+		this.p = p;
+	}
+}
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	
+	//현재 소포 배달 상태에서, idx번째 패킷을 배달하였을때의 상태를 반환하는 메소드
+	public static int setPakage(int pkg, int idx) {
+		return pkg|(1<<idx);
+	}
+	
+	public static void main(String[] args) throws IOException {
+		HashMap<String, Integer> hm = new HashMap<String, Integer>();
+		Queue<Node> q = new LinkedList<Node>();
+		int[][] dist = {{-1,0},{1,0},{0,-1},{0,1}};
+		String[] temp;
+		int N, M;
+		
+		temp = br.readLine().split(" ");
+		N = Integer.parseInt(temp[0]);
+		M = Integer.parseInt(temp[1]);
+		
+		//방문여부를 저장할 배열, v[y][x][i][p]에 대하여
+		//y, x위치에, i방향으로, p라는 형태로 배달한 상태로 방문했는지 아닌지를 나타냄
+		boolean[][][][] v = new boolean[N][M][5][4];
+		char[][] map = new char[N][M];
+
+		for(int i=0; i<N; i++) {
+			temp = br.readLine().split("");
+			for(int j=0; j<M; j++) {
+				map[i][j] = temp[j].charAt(0);
+				//만약 입력받은 위치가 시작 위치라면
+				if(map[i][j]=='S') {
+					//그것을 큐에 추가하고, 방문처리함
+					//방향은 4값을 갖도록 하여, 상하좌우 그 어느방향도 아님을 나타냄
+					q.add(new Node(i,j,4,0,0));
+					v[i][j][4][0] = true;
+					//그 후에 빈 공간으로 치환함
+					map[i][j] = '.';
+				//만약 배달 목적지라면
+				}else if(map[i][j] == 'C') {
+					//해시맵에 해당 소포의 위치와 그에 해당하는 인덱스를 저장해둠
+					hm.put(i+":"+j, hm.size());
+				}
+			}
+		}
+		
+		while(!q.isEmpty()) {
+			Node n = q.poll();
+			
+			//모든 소포가 배달이 완료된 것이라면 탐색을 종료함
+			if(n.p==3) {
+				bw.write(n.c+"\n");
+				bw.flush();
+				return;
+			}
+			
+			for(int i=0; i<dist.length; i++) {
+				int y = n.y + dist[i][0];
+				int x = n.x + dist[i][1];
+				if(y>=0&&y<N&&x>=0&&x<M) {
+					//만약 방향이 기존과 다르고, 아직 그 위치를 방문한 적이 없었다면
+					if(i!=n.d&&!v[y][x][i][n.p]) {
+						//그것이 배달 목적지라면
+						if(map[y][x]=='C') {
+							//해당 배달 목적지의 인덱스를 얻음
+							int idx = hm.get(y+":"+x);
+							//방문처리함
+							v[y][x][i][n.p] = true;
+							//해당 위치에서 다시 탐색할 수 있도록 노드를 추가함
+							//단, 현재 배달의 상태는 setPackage( )메소드를 사용해 갱신함
+							q.add(new Node(y,x,i,n.c+1,setPakage(n.p,idx)));
+						//만약 빈 공간이라면
+						}else if(map[y][x]=='.') {
+							//방문처리함
+							v[y][x][i][n.p] = true;
+							//방향만 전환한채로 그 위치에서 다시 탐색할 수 있도록 노드를 추가함
+							q.add(new Node(y,x,i,n.c+1,n.p));
+						}
+					}
+				}
+			}
+		}
+		
+		//배달할 수 없음
+		bw.write(-1+"\n");
+		bw.flush();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/1175)


문제 요구사항 : 

<pre>
해당 문제는 BFS탐색을 구현할 때에 방문배열을 어떻게 설정해야 하는지,
방문배열을 사용할 때에 비트마스킹을 활용하는 방법을 알고 있는지 묻는 문제임.
</pre>

접근 방법 : 

<pre>
해당 문제는 기본적인 미로탐색 BFS와는 달리, 도착 위치가 고정되어 있지 않음.
BFS가 중간에 종료될 수 있는 조건은, 2개의 위치에 도달하는 것인데
해당 위치에 도달했는지 아닌지를 저장하기 위해서는 전역변수로 HashMap을 선언해서
저장하거나, Node 클래스 자체에 HashMap을 추가하여 해당 배달 목적지에 도착했을때
그 위치 정보를 저장하는 방법도 있을 수 있음.

그러나, 이는 메모리 및 시간복잡도 면에서 모두 상당히 비효율적인 구현방법임.
특히 BFS탐색을 진행하면서 첫 번째 목적지에 도착했을때, 두 번째 목적지로 가기 위해서는
첫 번째 목적지에 도달하기 위해 방문했던 위치를 다시 방문할 수 있어야 하는데
매번 방문배열을 초기화해서는 해결할 수 없음.

이는 비트마스킹을 활용해 해결할 수 있음.
배달 목적지의 수는 2개 밖에 존재하지 않으며, 이는 2^2 = 4개의 방문 배열만 있으면
굳이 방문배열을 초기화하지 않고도 문제를 해결할 수 있게 됨.

두 배달 목적지를 각각 C1, C0라고 했을 때의 상태를 2진 비트로 표현하자면
(단, ( )안의 숫자는 진법을 의미함)

1. C1에만 도달했을 때 : 10(2) = 2(10)

2. C0에만 도달했을 때 : 01(2) = 1(10)

3. C1, C0 모두 도달했을 때 : 11(2) = 3(10)

4. C1, C0 모두 도달하지 못했을 때 : 00(2) = 0(10)

과 같이 10진법으로 나타낼 수 있음.

즉, 방문배열 v[y][x][i][p]에 대하여 각각의 y, x, i, p가 의미 하는 바는
y, x위치에 i (상, 하, 좌, 우, 정지중 하나)의 방향으로, 현재 p의 배달상태로 도달한 적이 있는 지를 나타냄.
</pre>

[유사한 문제 URL](https://www.acmicpc.net/problem/1194)

풀이 순서 : 

<pre>
1. 지도를 입력 받고, 시작 위치라면 큐에 추가하고 빈 공간으로 변경함(쉽게 문제 해결하기 위함)

2. BFS탐색을 실시하는데, 자신의 기존 방향과 다르고, 방문하지 않은 위치일때

2-1. 그것이 배달 목적지라면 배달 상태를 갱신하여 새로운 노드를 큐에 추가함.

2-2. 그것이 빈 공간이라면, 배달 상태를 그대로 간직한 채 새로운 노드를 큐에 추가함.

2-3. 모든 소포를 배달 완료했다면 BFS 탐색을 종료함.

3. 중간에 BFS탐색이 종료된 적이 없었다면, 배달을 완료할 수 없었다는 의미이므로 -1을 출력함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/188157633-04981e80-2942-405c-9f72-a2d9930cce77.png)