### PR TITLE
[BOJ] [BFS] [22255] [호석사우루스]

### DIFF
--- a/BOJ/BFS/22255/Blanc_et_Noir/Main.java
+++ b/BOJ/BFS/22255/Blanc_et_Noir/Main.java
@@ -1,0 +1,126 @@
+//https://www.acmicpc.net/problem/22255
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+//특정 위치에서의 정보를 저장할 노드 클래스
+class Node{
+	//각각 y, x좌표, 충격량, 어떤방향으로 이동해야할지 저장할 변수를 나타냄
+	int y, x, c, k;
+	Node(int y, int x, int c, int k){
+		this.y = y;
+		this.x = x;
+		this.c = c;
+		this.k = k;
+	}
+}
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	
+	public static int BFS(int[][] map, int SX, int SY, int EX, int EY) {
+		int[][] dist = {{-1,0},{1,0},{0,-1},{0,1}};
+		
+		//방향을 굳이 고려하지 않아도 되는 이유는 우선순위 큐를 활용하여 BFS탐색을 수행하고
+		//충격량이 모두 양수이므로 멀리 돌아서 해당위치에 도달하는 경우보다 지금 비용으로 도착했을때가
+		//가장 최소일 것이라 확신할 수 있기 때문임
+		boolean[][][] v = new boolean[map.length][map[0].length][3];
+		
+		//우선순위큐를 선언, 노드의 충격량이 가장 적은 노드가 먼저 반환됨
+		PriorityQueue<Node> pq = new PriorityQueue<Node>(new Comparator<Node>() {
+			@Override
+			public int compare(Node n1, Node n2) {
+				if(n1.c < n2.c) {
+					return -1;
+				}else if(n1.c > n2.c) {
+					return 1;
+				}else {
+					return 0;
+				}
+			}
+		});
+		
+		//시작위치를 방문처리함
+		v[SY][SX][0] = true;
+		
+		//우선순위큐에 노드를 추가함
+		pq.add(new Node(SY, SX, 0, 0));
+		
+		while(!pq.isEmpty()) {
+			Node n = pq.poll();
+
+			//도착위치에 도착했다면 BFS 탐색을 종료하고, 충격량을 반환함
+			//해당 충격량이 최소임은 우선순위 큐를 통해 보장할 수 있음
+			if(n.y == EY && n.x == EX) {
+				return n.c;
+			}
+			
+			for(int i=0; i<dist.length; i++) {
+				int y = n.y + dist[i][0];
+				int x = n.x + dist[i][1];
+				
+				//다음에 이동할 위치가 맵을 벗어나지 않고, 벽이 아니라면
+				if(y>=0&&y<map.length&&x>=0&&x<map[0].length&&map[y][x]!=-1) {
+					//3k번째 이동이거나
+					//3k+1 번째 이동이면서 상, 하 이동이거나
+					//3k+2 번째 이동이면서 좌, 우 이동인경우에만 이동 가능
+					
+					//여기서 중요한 것은 처음 이동할때는 0번째 이동이 아닌, 1번째 이동으로 취급한다는 것임
+					//즉, 처음 이동은 3k+1에 해당하기때문에, n.k를 3으로 나눈 나머지가 0이어야 함
+					if(n.k%3==2||(n.k%3==0&&(i==0||i==1))||(n.k%3==1&&(i==2||i==3))){
+						//해당 위치에 방문한 적이 없다면
+						if(!v[y][x][(n.k+1)%3]) {
+							//우선순위 큐에 다음 위치로의 이동 정보를 노드로 추가함
+							pq.add(new Node(y,x,n.c+map[y][x],(n.k+1)%3));
+							
+							//해당 위치에 방문 한 것으로 처리함
+							v[y][x][(n.k+1)%3] = true;
+						}
+					}
+				}
+			}
+		}
+		
+		//목적지에 도달할 수 없으므로 -1을 반환함
+		return -1;
+	}
+	
+	public static void main(String[] args) throws Exception{
+		//맵의 크기를 입력받음
+		String[] temp = br.readLine().split(" ");
+		int N = Integer.parseInt(temp[0]);
+		int M = Integer.parseInt(temp[1]);
+		
+		int[][] map = new int[N][M];
+		
+		//시작위치와 종료위치를 입력받음
+		temp = br.readLine().split(" ");
+		
+		//여기서 중요한 것은 일반적인 문제와는 달리 행, 열의 순서가 아니라
+		//열, 행의 순서로 좌표를 전달하고 있다는 사실임
+		//즉 이 문제에서 x좌표는 열이 아니라 행을 의미하고
+		//y좌표는 행이 아니라 열을 의미하므로 보통의 문제와는 달리 역순으로 입력받아야함
+		int SX = Integer.parseInt(temp[1])-1;
+		int SY = Integer.parseInt(temp[0])-1;
+		int EX = Integer.parseInt(temp[3])-1;
+		int EY = Integer.parseInt(temp[2])-1;
+		
+		//지도 정보를 입력받음
+		for(int i=0; i<N; i++) {
+			temp = br.readLine().split(" ");
+			for(int j=0; j<M; j++) {
+				map[i][j] = Integer.parseInt(temp[j]);
+			}
+		}
+		
+		bw.write(BFS(map,SX,SY,EX,EY)+"\n");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/22255)


문제 요구사항 : 

<pre>
해당 문제는 BFS탐색을 수행하되, 특정 조건에 따라 탐색 방향을 제한하여
BFS 탐색을 수행할 줄 아는지, 우선순위 큐를 활용한 BFS 탐색을 수행할 줄 아는지 묻는 문제임.
</pre>

접근 방법 : 

<pre>
일반적인 BFS 탐색 문제와는 달리 해당 문제는 우선순위 큐를 활용해야 하는데
이는 항상 누적된 충격량이 최소인 노드를 우선적으로 탐색하기 위함임.

또한 충격량은 양수로만 주어지므로 어떤 특정 위치에 도달한 적이 있었을때
다른 경로로 멀리 돌아서 해당 위치에 다시 도달한다면 처음 도착했을 때보다
더 많은 충격량이 필요하다고 확신할 수 있으므로 방문 배열을 boolean[y][x][k]의 형태로 구성함.

그러나, 만약 충격량이 음수로도 주어졌더라면, 해당 방식으로는 당연히 문제가 있음.
멀리 돌아서 오는 경우가 충격량이 더 적을 수도 있음.

그럴 때는 방문 배열을 int[y][x][k]의 형태로 구성하여 도착하는데 필요한 충격량을
저장해두었다가 방문 여부를 결정할 때 기존에 도착하는데 필요한 충격량보다
더 적은 충격량이 필요하다면 해당 위치부터 탐색할 수 있도록
우선순위 큐에 노드를 추가하면 됨.

또한 가장 처음의 이동은 3K번째 이동이 아니라 3K+1번째 이동인 것에 유의해야함.
즉, 처음에는 상 또는 하로만 이동 가능하고
그 이후부터 (좌, 우) - > (상, 하, 좌, 우) -> (상, 하) 와 같이 반복하여 이동하며

보편적인 BFS문제와는 달리 X좌표가 행, Y좌표가 열을 의미하므로
맵을 입력받을때, BFS 탐색을 수행할 때 이에 주의해야 함.
</pre>

풀이 순서 : 

<pre>
1. 맵의 정보와 시작 위치, 종료 위치를 모두 입력 받음.

2. BFS 탐색을 수행하되, 우선순위 큐를 활용함.

3. 방문 배열은 모두 정수의 최대값인 Integer.MAX_VALUE로 초기화 하되, 시작위치는 0으로 초기화 함.

4. 어떤 위치에 방문하고자 할 때 해당 방향으로 이동가능한지, 벽은 아닌지 판단해야 함.

5. 기존에 방문했었더라도 여태까지 누적된 충격량 + 해당 위치의 충격량이 기존에 도착했을때의 충격량보다 적다면 재 방문이 가능하도록 처리함.

6. 종료 위치에 도달했다면 BFS 탐색을 종료함.

7. 종료 위치에 도달할 수 없다면 -1을 출력함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/189820689-131791b2-ce1b-407a-8e78-961d35d3cb68.png)