### PR TITLE
[BOJ] [Back-Tracking] [15650] [N과 M (2)]

### DIFF
--- a/BOJ/Back-Tracking/15650/inseonyun/main.cpp
+++ b/BOJ/Back-Tracking/15650/inseonyun/main.cpp
@@ -1,0 +1,44 @@
+
+//////////////////////////////////////////////////
+// BAEKJOON: 15649_N과 M (1)
+//////////////////////////////////////////////////
+
+#include <iostream>
+
+using namespace std;
+
+int N, M;
+int arr[9] = { 0, };
+bool visited[9] = { false, };
+void input() {
+	cin >> N >> M;
+}
+
+void solution(int now, int cnt) {
+	if (cnt == M) {
+		for (int i = 0; i < M; i++) 
+			cout << arr[i] << " ";
+		cout << "\n";
+	}
+	else {
+		for (int i = now; i <= N; i++) {
+			if (!visited[i]) {
+				visited[i] = true;
+				arr[cnt] = i;
+				solution(i + 1, cnt + 1);
+				visited[i] = false;
+			}
+		}
+	}
+}
+
+int main() {
+	ios::sync_with_stdio(false);
+	cin.tie(0);
+	cout.tie(0);
+
+	input();
+	solution(1, 0);
+
+	return 0;
+}


### PR DESCRIPTION
Source URL : https://www.acmicpc.net/problem/15650


문제 요구사항 :

+ 자연수 N과 M이 주어졌을 때, 아래 조건을 만족하는 길이가 M인 수열을 모두 구하는 프로그램을 작성하시오.
    + 1부터 N까지 자연수 중에서 중복 없이 M개를 고른 수열
    + 고른 수열은 오름차순이어야 한다.
+ 첫째 줄에 자연수 N과 M이 주어진다. (1 ≤ M ≤ N ≤ 8)
+ 한 줄에 하나씩 문제의 조건을 만족하는 수열을 출력한다. 
+ 중복되는 수열을 여러 번 출력하면 안되며, 각 수열은 공백으로 구분해서 출력해야 한다.


접근 방법 :

+ DFS로 접근하며, 탐색 시 방문 체크를 하고, 앞선 N과 M(1)과의 차이점은 매개변수 now와 cnt를 사용해 now는 현재 시작 값, cnt는 갯수로 사용하여, arr 값 대입은 now부터 N까지, 출력은 cnt == M일 때 수행하며, DFS 탐색 시cnt +=1 을 하여 재 탐색한다. 탐색 종료 후, 백트래킹을 위해 방문 체크를 다시 false 한다.


풀이 순서 :

1. N과 M을 입력 받는다.
2. DFS함수에서 now(현재 수열 인덱스), cnt(출력 개수)를 매개변수로 다음을 수행한다.
    + cnt값이 M(길이)와 같을 때, 수열의 내용을 출력한다.
    + 그렇지 않다면, for문 i = now부터, N까지 visited[ i ] 값이 false 라면, true로 변환 후, arr [ i ] 에 i 값을 넣고, 다음 탐색을 위해 DFS( i, cnt + 1)을 하여 탐색한다. 탐색이 종료되면, 계속해서 백트래킹을 하며 탐색 할 수 있도록 visited[ i ] 값을 false로 한다.
    + 이와 같은 작업 반복


문제 풀이 결과 : 

![image](https://user-images.githubusercontent.com/84364741/190903317-05c8b0bd-4a7e-4fc7-8db8-17c036b50c9a.png)
