### PR TITLE
[PGS] [BFS] [경주로 건설]

### DIFF
--- a/PGS/BFS/경주로-건설/Blanc_et_Noir/Solution.java
+++ b/PGS/BFS/경주로-건설/Blanc_et_Noir/Solution.java
@@ -1,0 +1,92 @@
+//https://school.programmers.co.kr/learn/courses/30/lessons/67259
+
+import java.util.*;
+
+//각각 y, x좌표, 방향, 소모한 비용 정보를 저장할 노드클래스 선언
+class Node{
+    int y, x, d, c;
+    Node(int y, int x, int d, int c){
+        this.y = y;
+        this.x = x;
+        this.d = d;
+        this.c = c;
+    }
+}
+
+class Solution {
+    public int solution(int[][] board) {
+        int answer = 0;
+        
+        //방문 배열은 3차원으로 구성, int[y][x][d]이며 특히 d는 방향을 의미하는데
+        //이 문제에서는 반드시 방향을 고려해야만 함
+        //목적지에 도달하기 위해서 회전을 하면서 도착한 것과, 직진해서 도착한 것은 비용적으로 차이가 있음
+        int[][][] v = new int[board.length][board[0].length][5];
+        int[][] dist = {{-1,0},{1,0},{0,-1},{0,1}};
+
+        //비용이 적은 노드가 먼저 반환되도록 하는 우선순위 큐 선언
+        PriorityQueue<Node> pq = new PriorityQueue<Node>(new Comparator<Node>(){
+            @Override
+            public int compare(Node n1, Node n2){
+                if(n1.c<n2.c){
+                    return -1;
+                }else if(n1.c>n2.c){
+                    return 1;
+                }else{
+                    return 0;
+                }
+            }
+        });
+
+        //0,0좌표에서 시작, 방향은 4를 지정하여 초기상태를 나타냄
+        //비용을 -500으로 지정한 이유는, 첫 방향 4이며 이 상태에서는 어떤식으로 이동하든지 간에 반드시
+        //기존에 이동한 방향과는 다른 방향으로 이동했다고 생각하기 때문임.
+        //즉, 맨 처음에는 직진으로 이동하되, 방향이 바뀌면서 이동했다고 생각하기에 600의 비용을 소모하게 되는데
+        //이를 상쇄시키기 위해 500을 역으로 빼는 것임
+        pq.add(new Node(0,0,4, -500));
+        v[0][0][4] = 100;
+        
+        //방문 배열을 모두 정수의 최대치로 초기화함
+        //이유는, 방문 배열에는 해당 위치에 도달하기위해 여태까지 소모한 비용의 최소값을 저장해두는데
+        //초기화를 하지 않으면 비용이 0이 되므로 BFS탐색이 실행조차 되지 않음
+        for(int i=0; i<v.length; i++){
+            for(int j=0; j<v[0].length; j++){
+                for(int k=0; k<v[0][0].length; k++){
+                    v[i][j][k] = Integer.MAX_VALUE;
+                }
+            }
+        }
+        
+        while(!pq.isEmpty()){
+            Node n = pq.poll();
+            
+            //목적지에 도달했다면 그 비용을 반환함
+            if(n.y==board.length-1&&n.x==board[0].length-1){
+                answer = n.c;
+                break;
+            }
+            
+            for(int i=0; i<dist.length; i++){
+                int y = n.y + dist[i][0];
+                int x = n.x + dist[i][1];
+                
+                //해당 위치가 맵을 벗어나지 않고, 벽이 아닌 빈 공간이라면
+                if(y>=0&&y<board.length&&x>=0&&x<board[0].length&&board[y][x]!=1){
+                	//기존과 방향이 다르고 기존에 해당 위치에 방문 했던 비용보다 적거나, 동일한 비용을 소모했다면
+                    if(n.d!=i&&n.c+600<=v[y][x][i]){
+                    	//해당 지역을 방문할 수 있음
+                    	//비용이 500이 아닌 600이 추가되는 이유는 방향을 회전함과 동시에 직진하므로 500 + 100의 비용 필요
+                        pq.add(new Node(y,x,i,n.c+600));
+                        v[y][x][i] = n.c+600;
+                    //기존과 방향이 같고 기존에 해당 위치에 방문 했던 비용보다 적거나, 동일한 비용을 소모했다면
+                    }else if(n.d==i&&n.c+100<=v[y][x][i]){
+                    	//해당 지역을 방문할 수 있음
+                        pq.add(new Node(y,x,i,n.c+100));
+                        v[y][x][i] = n.c+100;
+                    }
+                }
+            }
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://school.programmers.co.kr/learn/courses/30/lessons/67259)


문제 요구사항 : 

<pre>
해당 문제는 문제 해결을 위한 BFS탐색의 원리와 방문 배열의 구조, 노드 클래스를 적절하게 정의할 줄 아는지 묻는 문제임.
</pre>

접근 방법 : 

<pre>
해당 문제는 방문배열은 단순히 boolean값 만을 갖는 것으로는 해결할 수 없음.
왜냐하면 이미 방문했던 위치에 대해 다시 방문할 수도 있어야 하기 때문임.

가령 경주로를 건설할 때 2000의 비용으로 해당 위치에 도달한 적이 있다 하더라도
다른 경로를 통해서는 1500이라는 더 적은 비용으로도 도달할 가능성이 있기 때문임.
이는 직진 및 회전에 필요한 비용이 서로 다르기 때문임.

따라서 해당 위치에 2000의 비용으로 방문한 적이 있더라도, 1500이라는 적은 비용으로 해당 위치에
방문하고자 한다면, 방문을 허락해야만 함.

또한 방문 배열은 3차원으로 구성해야만 함.
int[ ][ ] v = new int[y][x]와 같이 2차원으로 구성한다면 어떤 위치에 동일한 비용으로 도달하더라도
해당 위치 옆에 바로 목적지가 있을 때, 기존과 동일한 방향으로 목적지에 도달할 때는 +100,
기존과 다른 방향으로 목적지에 도달할 때는 +600의 비용이 필요함.
따라서 int[ ][ ][ ] v = new int[y][x][d] 와 같이 방향 또한 고려해야만 함. 

또한 해당 문제에서는 일반적인 큐가 아닌 우선순위 큐를 활용해야 함을 명심해야 함.
왜냐하면 목적지에 도달했다 하더라도 그것이 최소 비용으로 도착했는지 아닌 지를
노멀한 큐로는 보장할 수 없기 때문임.
</pre>

풀이 순서 : 

<pre>
1. 방문배열을 3차원으로 선언하되, 정수의 최대값으로 초기화 함.

2. 우선순위 큐에 시작 노드에 대한 정보를 저장함.

3. 목적지에 도달했다면 여태까지 소모한 비용을 출력함.

4. 아니라면 이동하고자 하는 방향이 기존방향과 같은지 다른지 판단함.

5. 다른 방향이면서 여태까지 소모한 비용 + 600 < 기존에 해당 위치에 도달하기 위해 소모한 최소 비용이면
   회전과 동시에 직진을 수행하므로 500 + 100 = 600만큼 비용을 소모하고 방문처리 함.

6. 같은 방향이라면 여태까지 소모한 비용 + 100 < 기존에 해당 위치에 도달하기 위해 소모한 최소 비용이면
   직진만 수행하므로 100만큼 비용을 소모하고 방문처리 함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/192134425-3ce7e636-204d-46f4-8d14-338ac61d1834.png)