### PR TITLE
[BOJ] [Topological-Sort] [2623] [음악프로그램]

### DIFF
--- a/BOJ/Topological-Sort/2623/Blanc_et_Noir/Main.java
+++ b/BOJ/Topological-Sort/2623/Blanc_et_Noir/Main.java
@@ -1,0 +1,104 @@
+//https://www.acmicpc.net/problem/2623
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	
+	//간선정보와 진입차수를 바탕으로 위상정렬을 수행 결과를 리턴하는 메소드
+	public static String topologicalSort(ArrayList<ArrayList<Integer>> graph, int[] indegree) throws IOException {
+		StringBuilder sb = new StringBuilder();
+		Queue<Integer> q = new LinkedList<Integer>();
+		int cnt=0;
+		
+		//진입차수가 0인 노드들을 큐에 추가함.
+		for(int i=0; i<indegree.length; i++) {
+			//진입차수가 0인 노드를 큐에 추가함.
+			if(indegree[i]==0) {
+				//큐에 추가되었다는 의미는, 자신으로 올 수 있는 다른 노드가 없다는 의미임.
+				q.add(i);
+				
+				//즉, 더이상 자신보다 먼저 선택되어야 할 노드가 없다는 뜻임
+				//따라서 위상정렬 순서에 맞게 배치된 노드의 개수를 1증가시킴
+				cnt++;
+			}
+		}
+
+		while(!q.isEmpty()) {
+			int A = q.poll();
+			
+			//해당 노드는 진입차수가 0이므로 자신보다 먼저 탐색되어야할 노드가 더이상 존재하지 않음.
+			//따라서, 해당 노드는 정렬 순서에 맞게 배치된 것임.
+			sb.append((A+1)+"\n");
+			
+			//진입차수가 0인 노드와 인접한 노드에 대해
+			//즉, 진입차수가 0인 노드가 먼저 선택되어야만 그 후에 선택될 수 있는 노드에 대하여
+			for(int i=0; i<graph.get(A).size(); i++) {
+				int B = graph.get(A).get(i);
+				
+				//해당 노드의 진입차수를 감소시킴
+				indegree[B]--;
+				
+				//그 진입차수가 0이된다면
+				if(indegree[B]==0) {
+					//해당 노드를 큐에 추가함.
+					q.add(B);
+					
+					//진입차수가 0이므로 이 노드는 지금 당장 선택되어도 되므로 정렬이 완료된 노드의 개수를 1증가시킴.
+					cnt++;
+				}
+			}
+		}
+		
+		//만약 위상정렬이 종료되었는데, 정렬이 완료된 노드의 수가 N이면
+		if(cnt==graph.size()) {
+			//모든 노드를 정렬할 수 있는 것임
+			return sb.toString();
+		//아니라면
+		}else {
+			//해당 간선정보로는 모든 노드를 정렬할 수 없음
+			//해당 간선정보에 사이클이 존재한다는 의미임
+			return "0\n";
+		}
+	}
+	
+	public static void main(String[] args) throws Exception {
+		String[] temp = br.readLine().split(" ");
+		int N = Integer.parseInt(temp[0]);
+		int M = Integer.parseInt(temp[1]);
+		
+		//진입차수를 저장할 배열 선언
+		int[] indegree = new int[N];
+		
+		//간선정보를 저장할 이중 리스트를 선언 및 초기화 함
+		ArrayList<ArrayList<Integer>> graph = new ArrayList<ArrayList<Integer>>();
+		for(int i=0; i<N; i++) {
+			graph.add(new ArrayList<Integer>());
+		}
+		
+		//간선정보를 입력받고 진입차수를 계산함
+		for(int i=0; i<M; i++) {
+			temp = br.readLine().split(" ");
+			for(int j=1; j<temp.length-1; j++) {
+				int A = Integer.parseInt(temp[j])-1;
+				int B = Integer.parseInt(temp[j+1])-1;
+				
+				indegree[B]++;
+				graph.get(A).add(B);
+			}
+		}
+		
+		bw.write(topologicalSort(graph,indegree));
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/2623)


문제 요구사항 : 

<pre>
해당 문제는 위상 정렬의 기본 동작 원리와 구현 방법을 알고 있는지 묻는 문제임.
</pre>

접근 방법 : 

<pre>
위상 정렬은 우선 순위가 정해진 작업을 우선 순위를 고려하여 순서대로 수행해야 할 때 사용할 수 있는 정렬임.
그런데 이러한 위상 정렬을 수행하기 위해서는 아래와 같은 조건이 성립해야만 함.

1. 방향이 존재하는 그래프여야 함.

2. 그래프에 사이클이 존재하면 안 됨.

1 -> 2
2 -> 3
3 -> 1

와 같은 작업 우선순위가 주어진다면, 우리는 1번, 2번, 3번 작업 중 어떤 작업을 먼저 수행할 지 쉽게 결정할 수 없음.
1번을 먼저 수행하려면 3번이 수행되어야 하고, 3번을 수행하려면 2번을, 2번을 수행하려면 1번 작업을 수행해야 하는
모순적인 상황이 발생함.

또한 방향이 없는 무방향 그래프에서는 위상정렬을 수행할 수 없음.

1 <-> 2
2 <-> 3
3 <-> 1

이라는 무방향 그래프에서는 1을 수행하기 위해서 2를 먼저 수행해야 하지만
2를 수행하기 위해서는 1을 먼저 수행해야 한다는 사이클이 필연적으로 발생하기 때문임.

사이클이 존재하는지 아닌지 유무를 판단할 수 있으면 해당 문제를 해결할 수 있음.
사이클이 없어야만 각각의 PD가 제출한 순서에 맞게 모든 가수들을 순서대로 정할 수 있음.

사이클의 유무를 판단하는 방법은 간단함.
사이클이 존재한다면 결코 자신으로 올 수 있는 노드의 수가 절대로 0이 될 수 없음
위상정렬을 모두 수행했을 때 진입차수가 0이 아닌 노드가 있다면 해당 노드는 절대로 순서를 정할 수 없다는 뜻임.
따라서 N개의 노드에 대하여 위상정렬을 수행했을 때 순서를 확정지을 수 있는 노드의 수가 N미만이라면
이는 사이클 때문에 순서를 확정지을 수 없는 노드가 있다는 뜻임.
</pre>

풀이 순서 : 

<pre>
1. 간선정보를 입력받고, 이에 따라 진입차수를 설정함.

2. 위상정렬을 수행하면서 순서를 확정 지을 수 있는 노드가 있다면 그 개수를 카운트 함.

3. 위상정렬 종료시에 확정지을 수 있는 노드의 개수가 N이면 정렬 순서를 출력하고
   N미만이라면 정렬이 불가능한 것이므로 0을 출력함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/193403267-e30407d3-4099-4c16-860a-5ebb57aca598.png)