### PR TITLE
[BOJ] [BFS] [20419] [화살표 미로 (Easy)]

### DIFF
--- a/BOJ/BFS/20419/Blanc_et_Noir/Main.java
+++ b/BOJ/BFS/20419/Blanc_et_Noir/Main.java
@@ -1,0 +1,135 @@
+//https://www.acmicpc.net/problem/20419
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.LinkedList;
+import java.util.Queue;
+
+//y, x좌표 및 좌회전, 우회전 주문서의 개수를 저장할 클래스
+class Node{
+	int y, x, l, r;
+	Node(int y, int x, int l, int r){
+		this.y = y;
+		this.x = x;
+		this.l = l;
+		this.r = r;
+	}
+}
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+	//입력받은 문자를 0 ~ 3 사이의 정수로 변환하는 메소드
+	public static int encode(char ch) {
+		switch(ch) {
+			case 'U':return 0;
+			case 'R':return 1;
+			case 'D':return 2;
+			default:return 3;
+		}
+	}
+	
+	public static void main(String[] args) throws Exception {
+		String[] temp = br.readLine().split(" ");
+		String answer = "No";
+		
+		int[][] dist = {{-1,0},{0,1},{1,0},{0,-1}};
+		
+		int R = Integer.parseInt(temp[0]);
+		int C = Integer.parseInt(temp[1]);
+		
+		//주문서 쌍의 개수
+		int K = Integer.parseInt(temp[2]);
+		
+		int[][] m = new int[R][C];
+		
+		//방문배열은 y, x좌표 및 남은 좌회전, 우회전 주문서의 개수 등 4차원으로 구성함
+		boolean[][][][] v = new boolean[R][C][K+1][K+1];
+		
+		//맵 정보를 입력받음
+		for(int i=0; i<R; i++) {
+			char[] arr = br.readLine().toCharArray();
+			for(int j=0; j<C; j++) {
+				m[i][j] = encode(arr[j]);
+			}
+		}
+		
+		//BFS탐색에 사용할 큐 선언
+		Queue<Node> q = new LinkedList<Node>();
+		
+		//0,0 위치에서 좌, 우회전 주문서 각각 K개를 보유한 상태로 방문한 적이 있는 것으로 처리함
+		v[0][0][K][K] = true;
+		
+		q.add(new Node(0,0,K,K));
+		
+		while(!q.isEmpty()) {
+			Node n = q.poll();
+			
+			//도착지점에 도착했다면
+			if(n.y==R-1&&n.x==C-1) {
+				//도착할 수 있는 것으로 처리함
+				answer = "Yes";
+				break;
+			}
+			
+			//현재 위치의 타일이 가리키는 방향
+			int d = m[n.y][n.x];
+			
+			//해당 타일의 방향대로 움직였을때의 좌표
+			int y = n.y + dist[d][0];
+			int x = n.x + dist[d][1];
+			
+			//만약 이동하려는 좌표가 맵의 범위를 벗어나지 않으면
+			if(y>=0&&y<R&&x>=0&&x<C) {
+				//해당 위치에 방문한 적이 없다면
+				if(!v[y][x][n.l][n.r]) {
+					//해당위치를 방문함
+					v[y][x][n.l][n.r] = true;
+					q.add(new Node(y,x,n.l,n.r));
+				}
+			}
+			
+			//좌회전 주문서가 남아있으면
+			if(n.l>0) {
+				//현재 방향을 90도 좌로 회전한 새로운 방향
+				int nd = (d+4-1)%4;
+				
+				//바뀐 방향으로 이동했을때의 좌표
+				y = n.y + dist[nd][0];
+				x = n.x + dist[nd][1];
+				
+				//해당 위치로 주문서를 1개 사용했을때 방문한 적이 없다면
+				if(y>=0&&y<R&&x>=0&&x<C&&!v[y][x][n.l-1][n.r]) {
+					//해당위치를 방문함
+					v[y][x][n.l-1][n.r] = true;
+					q.add(new Node(y,x,n.l-1,n.r));
+				}
+			}
+
+			//우회전 주문서가 남아있으면
+			if(n.r>0) {
+				//현재 방향을 90도 좌로 회전한 새로운 방향
+				int nd = (d+1)%4;
+				
+				//바뀐 방향으로 이동했을때의 좌표
+				y = n.y + dist[nd][0];
+				x = n.x + dist[nd][1];
+				
+				//해당 위치로 주문서를 1개 사용했을때 방문한 적이 없다면
+				if(y>=0&&y<R&&x>=0&&x<C&&!v[y][x][n.l][n.r-1]) {
+					//해당위치를 방문함
+					v[y][x][n.l][n.r-1] = true;
+					q.add(new Node(y,x,n.l,n.r-1));
+				}
+			}
+		}
+		
+		bw.write(answer+"\n");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/20419)


문제 요구사항 : 

<pre>
해당 문제는 BFS 탐색의 기본 원리와 구성 방법, 이에 필요한 적절한 방문 배열 형태를 구현할 줄 아는지 묻는 문제임.
</pre>

접근 방법 : 

<pre>
해당 문제에서 회전을 할 수 있는 횟수는 좌, 우회전 모두 K번으로 고정되어있으며,
어떤 위치에 서로 다른 방향에서 진입했을 때의 비용이 달라지는 것은 아니므로
굳이 방문 배열에 방향을 고려할 필요는 없음.

방향 i에 대하여 i=0일때는 상, i=1일때는 우, i=2일때는 하, i=3일때는 좌를 가리키도록 설정함.

방향 회전의 경우, 우회전은 시계방향으로 회전하기에 현재의 방향이 i라면
회전 후 방향은 (  i + 1 ) % 4 로 쉽게 구할 수 있음.

좌회전은 반 시계방향으로 회전하기에 현재의 방향이 i라면
회전 후 방향은 ( i + 4 - 1 ) % 4로 쉽게 구할 수 있음.

타일의 방향에 맞게 이동하는 것은 주문서 보유 개수에 상관없이 해야하며
좌, 우회전은 주문서를 보유했을때 하도록 해야함.
</pre>

풀이 순서 : 

<pre>
1. 맵의 정보를 입력 받음. 이때 맵의 각 칸은 정수값을 갖는데
   0은 상, 1은 우, 2는 하, 3은 좌 방향으로 이동해야 함을 가리킴.

2. BFS탐색을 수행하면서 타일의 방향에 맞게 이동하는 것은 매번 수행하고
   좌, 우회전은 해당 방향으로 회전 할 수 있는 주문서가 남아있을때만 수행함.

3. 맵의 최우하단에 도착하면 BFS탐색을 종료하고 Yes를 출력함.

4. 아니라면 No를 출력함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/193857773-76ca2dc3-7d42-40d5-9529-cff69a22d9d6.png)