### PR TITLE
[BOJ] [Bit-Masking] [2064] [IP 주소]

### DIFF
--- a/BOJ/Bit-Masking/2064/Blanc_et_Noir/Main.java
+++ b/BOJ/Bit-Masking/2064/Blanc_et_Noir/Main.java
@@ -1,0 +1,95 @@
+//https://www.acmicpc.net/problem/2064
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	
+	public static String getString(long num) {
+		String result = "";
+		
+		for(int i=3; i>=0; i--) {
+			int digit = 1;
+			long sum = 0;
+			for(int j=0; j<8; j++) {
+				long bit = getBit(num,8*i+j);
+				sum += digit*bit;
+				digit*=2;
+			}
+			
+			if(i>0) {
+				result+=sum+".";
+			}else {
+				result+=sum;
+			}
+		}
+		return result;
+	}
+	
+	public static long getBit(long num, int b) {
+		return ((num&(1<<b))>>>b);
+	}
+	
+	public static long setBit(long num, int b, int v) {
+		if(v==0) {
+			return (num&(~(1<<b)));
+		}else {
+			return (num|(1L<<b));
+		}
+	}
+	
+	public static boolean checkBit(long[] arr, int b) {
+		for(int i=0; i<arr.length-1; i++) {
+			if(getBit(arr[i],b)!=getBit(arr[i+1],b)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	public static void main(String[] args) throws Exception {
+		int N = Integer.parseInt(br.readLine());
+		long[] arr = new long[N];
+		
+		for(int i=0; i<N; i++) {
+			String[] temp = br.readLine().split("\\.");
+			for(int j=0; j<temp.length; j++) {
+				arr[i] += Long.parseLong(temp[j])<<(8*(3-j));
+			}
+		}
+		
+		int len = -1;
+		
+		
+		
+		for(int i=31; i>=0; i--) {
+			if(!checkBit(arr,i)) {
+				len = i;
+				break;
+			}
+		}
+		
+		long address = arr[0];
+		long mask = arr[0];
+
+		for(int i=31; i>len; i--) {
+			mask = setBit(mask,i,1);
+		}
+		
+		for(int i=len; i>=0; i--) {
+			address = setBit(address,i,0);
+			mask = setBit(mask,i,0);
+		}
+
+		bw.write(getString(address)+"\n");
+		bw.write(getString(mask)+"\n");
+		
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/2064)


문제 요구사항 : 

<pre>
해당 문제는 비트 마스킹을 적절히 활용하여 상태를 저장하는 방법을 알고 있는지 묻는 문제임.
</pre>

접근 방법 : 

<pre>
문제의 제목을 보면 짐작할 수 있듯이, 네트워크에 대한 기본적인 이해가 있으면 더욱 쉽게 문제를 해결할 수 있음.

IP란 Internet Protocol의 약자로, OSI 7계층중 Network Layer에 속하는 프로토콜로써,
IP주소는 호스트의 상대적 위치, 상대적 주소를 나타냄.

IPv6와는 달리 IPv4는 8비트씩 4개를 하나의 묶음으로 사용, 즉 32비트를 활용하여 주소를 표현함.
이러한 IP주소는 누구나 마음대로 가져다 사용할 수 있는 것이 아니라, 국제 기관인 ICANN에서
각 국가별로, ISP별로 IP 주소 대역을 할당하며, 일반 사용자들은 그러한 ISP로부터  할당 받음.

이때 ISP가 ICANN으로부터 할당 받은 32비트의 IP주소 블록을 자신들의 사정에 맞게 분할하여 체계적으로 관리하는데
IP주소를 각각 서브넷 파트와 호스트 파트로 나눔.

같은 서브넷에 존재하는 호스트들은 서브넷 파트의 비트가 모두 동일하며, 호스트 파트의 비트만 독립적인 값을 가짐.
서브넷 마스크는, 어떤 IP주소에 대하여, 서브넷 파트를 쉽게 얻을 수 있도록 마스킹할때 사용하는 비트패턴을 말함.

가령 IP주소가 11000000.10101000.0111011.10000100( 192.168.123.132 )이며
서브넷 마스크가 11111111.11111111.11111111.00000000 ( 255.255.255.0 )이라면

두 비트를 AND 비트연산한 결과인 11000000.10101000.0111011.00000000 ( 192.168.123.0 )이 바로 서브넷 주소가 됨.

해당 문제에서는 서브넷 마스크의 1비트가 최대가 되는 서브넷 주소와 마스크를 묻고 있으므로
입력으로 주어진 모든 IP주소에 대하여 MSB부터 탐색하여 최대한 모두 동일한 비트를 갖는 부분까지를 1비트로 갖는
서브넷 마스크를 얻고 해당 서브넷 마스크로 입력으로 주어진 IP주소중 하나를 마스킹하면 서브넷 주소를 얻을 수 있음.
</pre>

풀이 순서 : 

<pre>
1. 모든 IP주소를 입력 받음.

2. 모든 IP주소를 MSB부터 탐색하여 최초로 비트가 동일하지 않은 지점을 찾음.

3. MSB부터 최초로 비트가 동일하지 않은 지점 바로 이전까지의 비트를 모두 1로 하고
   그 뒤의 비트를 모두 0으로 하는 서브넷 마스크를 구함.

4. IP주소 하나를 3에서 구한 서브넷 마스크로 마스킹하여 서브넷 주소를 구함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/194704591-570a3ef0-0035-4da2-9fe5-bcb50810c112.png)