### PR TITLE
[BOJ] [BFS] [2178] [미로 탐색]

### DIFF
--- a/BOJ/BFS/2178/P-digit/main.py
+++ b/BOJ/BFS/2178/P-digit/main.py
@@ -1,0 +1,33 @@
+from collections import deque
+import sys
+
+input = sys.stdin.readline
+
+rs, cs = map(int, input().strip().split())
+
+board = [input().strip('\n') for _ in range(rs)]
+dx = (1, 0, -1, 0)
+dy = (0, -1, 0, 1)
+
+def is_valid(y, x):
+    return 0 <= y < rs and 0 <= x < cs
+
+def bfs():
+    chk = [[False] * cs  for _ in range(rs)] 
+    chk[0][0] = True
+    dq = deque()
+    dq.append((0, 0, 1))
+    while dq:
+        y, x, d = dq.popleft()
+
+        if y == rs-1 and x == cs-1:
+            return d
+
+        for i in range(4):
+            ny = y + dy[i]
+            nx = x + dx[i]
+            if is_valid(ny, nx) and board[ny][nx] == "1" and not chk[ny][nx]:
+                chk[ny][nx] = True
+                dq.append((ny, nx, d+1))
+
+print(bfs())


### PR DESCRIPTION
Source URL : 
[문제](https://www.acmicpc.net/problem/2178)

문제 요구사항 : 
NxM 크기의 배열에서 (1,1) 위치에서 시작해 (N,M) 까지 도달하는 데 이동하는 최소의 칸 수 구하기

접근 방법 : 
탐색할 때 최소값을 원하므로 파이썬의 deque을 이용해 bfs 사용

풀이 순서 : 
1. 배열 정보를 받음

2. bfs를 수행해 (N,M)에 도달할 최소의 칸 수 출력 


문제 풀이 결과 : 
![image](https://user-images.githubusercontent.com/62891362/194736416-2eb00664-d455-48a4-9fab-f262f520e96b.png)

