### PR TITLE
[BOJ] [Two-Pointer] [1806] [부분합]

### DIFF
--- a/BOJ/Two-Pointer/1806/Blanc_et_Noir/Main.java
+++ b/BOJ/Two-Pointer/1806/Blanc_et_Noir/Main.java
@@ -1,0 +1,69 @@
+//https://www.acmicpc.net/problem/1806
+
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+	public static void main(String[] args) throws Exception {
+		String[] temp = br.readLine().split(" ");
+		
+		int N = Integer.parseInt(temp[0]);
+		int S = Integer.parseInt(temp[1]);
+		int C = Integer.MAX_VALUE;
+		
+		int[] arr = new int[N];
+		
+		//N개의 정수를 입력 받음
+		temp = br.readLine().split(" ");
+		
+		//입력받은 정수를 배열에 저장함
+		for(int i=0; i<temp.length; i++) {
+			arr[i] = Integer.parseInt(temp[i]);
+		}
+		
+		//L과 R은 포인터, T는 현재까지 계산된 부분합을 저장할 변수
+		int L=0, R=0, T=0;
+		
+		while(true) {
+			//현재까지 계산된 부분합이 S보다 크거나, S와 같은 경우
+			if(T>=S) {
+				//부분합의 길이가 기존의 최소 길이보다도 작다면
+				if(R-L<C) {
+					//그것을 최소 길이로 갱신함
+					C = R - L;
+				}
+				
+				//L포인터가 가리키는 만큼의 값을 부분합에서 제외하고, L포인터를 우측으로 1칸 이동시킴
+				T -= arr[L++];
+			//만약 R포인터가 범위를 벗어났으면
+			}else if(R==N) {
+				//탐색을 종료함
+				break;
+			//현재까지 계산된 부분합이 S보다 작다면
+			}else {
+				//R포인터가 가리키는 만큼의 값을 부분합에 포함시키고, R포인터를 우측으로 1칸 이동시킴
+				T += arr[R++];
+			}
+		}
+		
+		//만약 최소길이가 갱신된 적이 없다면
+		if(C==Integer.MAX_VALUE) {
+			//부분합이 S가 되는 연속되는 수열이 없으므로 그 길이를 0으로 출력함
+			bw.write(0+"\n");
+		//만약 최소 길이가 갱신된 적이 있다면
+		}else {
+			//부분합이 S가 되는 연속되는 수열의 최소 길이를 출력함.
+			bw.write(C+"\n");
+		}
+		
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/1806)


문제 요구사항 : 

<pre>
해당 문제는 투 포인터 알고리즘을 적절히 활용할 줄 아는지 묻는 문제임.
</pre>

접근 방법 : 

<pre>
해당 문제에서 주어지는 숫자들은 오름차순으로 정렬되어 있지 않으며, 음수가 존재하는 것도 아님.

어떤 연속적인 부분수열의 합 T에 대하여, 그것이 목표값 S보다 작다면, 우측 포인터를 1칸 오른쪽으로 이동시키면
T값은 기존의 T값보다는 증가한 값이 될 것임. 왜냐하면 입력으로 주어진 숫자들은 모두 양수이기 때문임.

반대로, 연속적인 부분수열의 합 T가 목표값인 S보다 크다면 좌측 포인터를 1칸 오른쪽으로 이동시키면
T값은 기존의 T값보다는 감소한 값이 될 것임. 왜냐하면 입력으로 주어진 숫자들에는 음수가 없기 때문임.

만약 T값이 S값과 같다면 좌측 포인터를 1칸 오른쪽으로 이동시켜야 함.
왜냐하면, 해당 문제에서는 조건을 만족하는 부분수열의 길이가 최소가 되도록 해야하기 때문임.

만약 T값이 S값과 같을 때 우측 포인터를 1칸 오른쪽으로 이동시키면, T값이 S값보다 커지면서 동시에 부분수열의 길이도 증가함.
그러나, T값이 S값과 같을 때 좌측 포인터를 1칸 오른쪽으로 이동시키면 T값이 여전이 S보다는 커질 가능성이 있음.
따라서 T값과 S값이 같을 때는 좌측 포인터를 1칸 오른쪽으로 이동시켜 탐색을 진행함.
</pre>

풀이 순서 : 

<pre>
1. 정수를 입력받아 배열에 저장함.

2. 좌, 우측 포인터를 모두 시작위치에 위치시킴.

3. 부분수열의 합 T가 S보다 작다면 우측 포인터를 1칸 오른쪽으로 이동시키며, T값도 갱신함.

4. 부분수열의 합 T가 S보다 크거나, 같다면 좌측 포인터를 1칸 오른쪽으로 이동시키며, T값도 갱신함.

5. 만약 부분수열의 합 T가 S와 같았다면, 좌측, 우측 포인터의 위치의 차이의 절대값이
   최소 값과 비교하여 최소값보다 작다면 갱신함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/194737547-de76138e-0b93-4181-8d93-2e006510ddaf.png)