### PR TITLE
[BOJ] [BFS] [13459] [구슬 탈출]

### DIFF
--- a/BOJ/BFS/13459/Blanc_et_Noir/Main.java
+++ b/BOJ/BFS/13459/Blanc_et_Noir/Main.java
@@ -1,0 +1,202 @@
+//https://www.acmicpc.net/problem/13459
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.LinkedList;
+import java.util.Queue;
+
+//두 구슬의 위치와 기존에 움직인 방향, 움직인 횟수를 저장하는 노드 클래스 선언
+class Node{
+	Marble r, b;
+	int d, c;
+	
+	Node(Marble r, Marble b, int d, int c){
+		this.r = r;
+		this.b = b;
+		this.d = d;
+		this.c = c;
+	}
+}
+
+//구슬의 색상과 구슬의 y, x좌표를 저장하는 구슬 클래스
+class Marble{
+	char c;
+	int y, x;
+	Marble(char c, int y, int x){
+		this.c = c;
+		this.y = y;
+		this.x = x;
+	}
+}
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	
+	//현재 구슬의 상태와 이동할 방향을 분석하여 빨강구슬과 파랑구슬중 어떤 구슬이 먼저 움직여야 하는지 계산하는 메소드
+	public static boolean isRedFirst(Node n, int d) {
+		if((d==0&&n.r.y<n.b.y)||(d==1&&n.r.x>n.b.x)||(d==2&&n.r.y>n.b.y)||(d==3&&n.r.x<n.b.x)) {
+			return true;
+		}else {
+			return false;
+		}
+	}
+	
+	//구슬 m1에 대하여 d방향으로 기울였을때 도달하는 위치를 반환하는 메소드
+	//m2구슬은 m1구슬보다 먼저 움직인 구슬이며, m1구슬은 m2구슬에 가로막힐 수도 있음.
+	//m2구슬이 null인 경우 m1구슬은 벽에 부딫히거나 탈출구를 찾을때까지만 움직임.
+	public static Marble moveMarble(char[][] map, int d, Marble m1, Marble m2) {
+		Marble result = null;
+		
+		int[][] dist = {{-1,0},{0,1},{1,0},{0,-1}};
+		int y = m1.y;
+		int x = m1.x;
+		
+		//해당 d 방향으로 계속 탐색을 이어나감
+		while((y>=0&&y<map.length&&x>=0&&x<map[0].length)) {
+			//만약 탈출구를 만났다면
+			if(map[y][x]=='O') {
+				//구슬이 탈출했음을 알리도록 null값을 리턴함
+				break;
+			//만약 m2 구슬에 가로막힌 경우
+			}else if(m2!=null&&y==m2.y&&x==m2.x) {
+				//m2구슬에 부딫히기 직전까지의 위치를 리턴함
+				result = new Marble(m1.c,y-dist[d][0],x-dist[d][1]);
+				break;
+			//만약 구슬이 벽에 부딫힌 경우
+			}else if(map[y][x]=='#') {
+				//해당 벽에 부딫히기 직전까지의 위치를 리턴함
+				result = new Marble(m1.c,y-dist[d][0],x-dist[d][1]);
+				break;
+			}
+			
+			//벽에 부딫히지 않았거나, 다른 구슬과 충돌하지 않았거나, 탈출하지 않았다면
+			//d방향으로 한 칸 더 이동하여 다시 탐색을 수행함
+			y = y + dist[d][0];
+			x = x + dist[d][1];
+		}
+
+		//최종 구슬의 위치를 null 또는 Marble클래스로 리턴함
+		return result;
+	}
+	
+	public static int BFS(char[][] map, Marble r, Marble b) {
+		//방문 배열은 빨강구슬의 y, x좌표 및 파랑구슬의 y, x좌표를 인덱스로 함
+		//구슬의 최종 위치를 기록해두는 이유는 불필요한 반복을 줄이기 위함
+		boolean[][][][] v = new boolean[map.length][map[0].length][map.length][map[0].length];
+		
+		//최초 빨강, 파랑 구슬의 위치 및 초기 방향, 초기 이동 횟수를 노드에 저장함
+		Node node = new Node(r,b,4,1);
+		
+		//BFS탐색을 위한 큐를 선언함
+		Queue<Node> q = new LinkedList<Node>();
+		q.add(node);
+		
+		//방문 배열에 빨강 및 파랑 구슬의 위치에 대해 방문처리를 함
+		v[r.y][r.x][b.y][b.x] = true;
+		
+		while(!q.isEmpty()) {
+			Node n = q.poll();
+
+			//만약 10번을 초과하여 이동한 경우
+			if(n.c>10) {
+				//더이상 탐색하지 않음
+				continue;
+			}
+
+			for(int i=0; i<4; i++) {
+				int nd = i;
+				
+				//만약 기존에 기울인 적이 있고, 기존 이동방향을 기준으로 앞 또는 뒤로 이동하려는 경우
+				if(n.d!=4&&!(i==1||i==3)) {
+					//해당 방향은 중복되므로 굳이 탐색할 필요 없음
+					continue;
+				//만약 기울인적이 없거나, 기울인적이 있다 하더라도 기존 이동방향을 기준으로 좌 또는 우로 이동하려는 경우
+				}else {
+					//해당 방향으로 이동함
+					nd = (n.d+i)%4;
+				}
+				
+				//만약 빨강 구슬이 먼저 움직여야 한다면
+				if(isRedFirst(n,nd)) {
+					//빨강 구슬을 먼저 움직이고 그 최종 좌표를 얻음
+					Marble nr = moveMarble(map, nd, n.r, null);
+					
+					//파랑 구슬을 움직이되, 위치가 변경된 빨강 구슬과 충돌되는지 포함하여 그 최종 좌표를 얻음
+					Marble nb = moveMarble(map, nd, n.b, nr);
+					
+					//만약 파랑 구슬이 탈출한 경우
+					if(nb==null) {
+						//이는 실패한 것이므로 더는 탐색하지 않음
+						continue;
+					//만약 파랑구슬은 탈출에 실패했으나, 빨강구슬은 탈출에 성공한 경우
+					}else if(nr==null) {
+						//성공했음을 알리는 1을 반환함
+						return 1;
+					//만약 빨강구슬과 파랑구슬의 위치가 기존에는 없었던 새로운 좌표 쌍이라면
+					}else if(!v[nr.y][nr.x][nb.y][nb.x]){
+						//해당 지점에서 다시 BFS 탐색을 수행함
+						q.add(new Node(nr,nb,nd,n.c+1));
+						v[nr.y][nr.x][nb.y][nb.x] = true;
+					}
+				//만약 파랑 구슬이 먼저 움직여야 한다면
+				}else {
+					//파랑 구슬을 먼저 움직이고 그 최종 좌표를 얻음
+					Marble nb = moveMarble(map, nd, n.b, null);
+					
+					//빨강 구슬을 움직이되, 위치가 변경된 파랑 구슬과 충돌되는지 포함하여 그 최종 좌표를 얻음
+					Marble nr = moveMarble(map, nd, n.r, nb);
+					
+					//만약 파랑 구슬이 탈출한 경우
+					if(nb==null) {
+						//이는 실패한 것이므로 더는 탐색하지 않음
+						continue;
+					//만약 파랑구슬은 탈출에 실패했으나, 빨강구슬은 탈출에 성공한 경우
+					}else if(nr==null) {
+						//성공했음을 알리는 1을 반환함
+						return 1;
+					//만약 빨강구슬과 파랑구슬의 위치가 기존에는 없었던 새로운 좌표 쌍이라면
+					}else if(!v[nr.y][nr.x][nb.y][nb.x]){
+						//해당 지점에서 다시 BFS 탐색을 수행함
+						q.add(new Node(nr,nb,nd,n.c+1));
+						v[nr.y][nr.x][nb.y][nb.x] = true;
+					}
+				}
+			}		
+		}
+		
+		//10번이하의 기울이기로 빨강 구슬만을 탈출시키는 것이 불가능 하므로 0을 리턴함 
+		return 0;
+	}
+	
+	public static void main(String[] args) throws Exception {
+		String[] temp = br.readLine().split(" ");
+		
+		int N = Integer.parseInt(temp[0]);
+		int M = Integer.parseInt(temp[1]);
+		
+		char[][] map = new char[N][M];
+		
+		Marble r = null, b = null;
+		
+		//맵의 정보를 입력받음
+		for(int i=0; i<N; i++) {
+			map[i] = br.readLine().toCharArray();
+			for(int j=0; j<map[0].length; j++) {
+				//빨강 구슬 또는 파랑 구슬인 경우 그 좌표를 기록해둠
+				if(map[i][j]=='R') {
+					r = new Marble('R',i,j);
+				}else if(map[i][j]=='B') {
+					b = new Marble('B',i,j);
+				}
+			}
+		}
+		
+		bw.write(BFS(map,r,b)+"\n");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/13459)


문제 요구사항 : 

<pre>
해당 문제는 BFS탐색을 수행하되, 두 개의 객체 정보를 동시에 참조하여 수행할 줄 아는지,
불필요한 반복을 줄이기 위한 적절한 방문배열 구성 방법 등을 알고 있는지 묻는 문제임.
</pre>

접근 방법 : 

<pre>
해당 문제에서 주어지는 빨강 및 파랑 구슬은 각각 1개씩만 존재하며, 두 구슬은 한 번 기울일 때마다
동시에 움직여야 함. 이때, 각 구슬은 벽에 충돌하는 상황 뿐만 아니라 각각의 구슬 간의 충돌 또한 고려해야 함.

두  구슬의 x, y좌표가 동시에 동일한 경우는 절대 없으며
만약 왼쪽으로 기울인다면 좀 더 왼쪽에 있는 구슬이 먼저 이동하도록 BFS 탐색을 수행하면 되고,
만약 아래로 기울인다면 좀 더 아래에 있는 구슬이 먼저 이동하도록 BFS 탐색을 수행하면 됨.

또한 불필요한 탐색을 줄이기 위해서는 두 가지를 고려해야함.

1. 기존에 기울였던 방향과 수직을 이루는 방향으로만 기울여야함.
   만약 기존에 위쪽 방향으로 기울였는데, 이번에도 위쪽 방향으로 기울이는 것은
   구슬의 위치 변화가 없으므로 불필요한 행동이며

   만약 기존에 위쪽 방향으로 기울였는데, 반대로 아래쪽 방향으로 기울이는 것은 
   기껏 구슬을 움직여 놨더니, 다시 원상복구 시킨 꼴이 됨.

   따라서 위쪽 방향으로 기울였다면 그와는 수직을 이루는 방향인 왼쪽 또는 오른쪽 방향으로만 기울여야 함.

2. 빨강 구슬이 y1, x1, 파랑 구슬이 y2, x2위치에 도달한 적이 있다면
   여러 기울이기를 통해 다시 동일한 y1, x1, y2, x2 위치에 도달한다면 결국 여러 번 기울이고도
   기울인 적이 없는 상태와 동일한 꼴이 되므로 불필요한 행동임.

   이는 방문배열을 4차원으로 설정하여 각각의 인덱스가 빨강 구슬의 y, x좌표, 파랑 구슬의 y, x좌표를 갖고
   boolean 값으로 true 또는 false를 저장하도록 함으로써 해결할 수 있음.
</pre>

풀이 순서 : 

<pre>
1. 맵의 정보 및 구슬의 초기 위치를 입력 받음.

2. 기울이고자 하는 방향을 분석하여 어떤 구슬이 먼저 움직여야 하는지 판단함.

3. 먼저 움직이는 구슬은 벽 또는 탈출구를 만나는 지만 탐색하면 되며
   나중에 움직이는 구슬은 벽이나 탈출구 또는 먼저 움직인 구슬의 새로운 위치를 만나는지 고려하여 탐색해야 함.

4. 만약 파랑구슬이 탈출했다면 빨강 구슬의 탈출여부와 상관없이 실패임.

5. 만약 파랑구슬이 탈출하지 못했는데 빨강 구슬이 탈출했다면 성공임.

6. 두 구슬 모두 탈출하지 못했고, 기울인 후의 빨강 구슬 및 파랑 구슬이 해당 위치에 도달한 적이 없다면
   탐색 횟수를 1 증가시키고 다시 BFS 탐색을 수행하도록 함.

7. 만약 탐색횟수가 10번을 초과했다면 해당 정보로는 더이상 BFS 탐색을 수행하지 않음.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/194768375-3c099ea8-b45b-44d6-877b-848cf5d7b4e2.png)