### PR TITLE
[BOJ] [BFS] [14502] [연구소]

### DIFF
--- a/BOJ/BFS/14502/Blanc_et_Noir/Main.java
+++ b/BOJ/BFS/14502/Blanc_et_Noir/Main.java
@@ -1,0 +1,151 @@
+//https://www.acmicpc.net/problem/14502
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Queue;
+
+class Node{
+	int y, x;
+	Node(int y, int x){
+		this.y = y;
+		this.x = x;
+	}
+}
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static int max = Integer.MIN_VALUE;
+	
+	public static int BFS(int[][] map, Queue<Node> virus, Node[] wall, int Z) {
+		boolean[][] v = new boolean[map.length][map[0].length];
+		int[][] dist = {{-1,0},{1,0},{0,-1},{0,1}};
+		int C = 0;
+		
+		//모든 바이러스들에 대하여 BFS탐색을 수행함
+		Iterator<Node> itor = virus.iterator();
+		
+		while(itor.hasNext()) {
+			//바이러스 하나를 선택하여 큐에 추가함
+			Queue<Node> q = new LinkedList<Node>();
+			Node node = itor.next();
+			q.add(node);
+			
+			//바이러스의 초기 위치에 방문했음을 표시함
+			v[node.y][node.x] = true;
+			
+			while(!q.isEmpty()) {
+				Node n = q.poll();
+				
+				//바이러스의 현재 위치를 기준으로 상하좌우 방향으로 탐색함
+				for(int j=0; j<dist.length; j++) {
+					int y = n.y + dist[j][0];
+					int x = n.x + dist[j][1];
+					
+					//바이러스가 이동하고자 하는 다음 위치가 맵의 범위를 벗어나지 않고, 방문한 적도 없으며, 빈 공간이라면
+					if(y>=0&&y<map.length&&x>=0&&x<map[0].length&&!v[y][x]&&map[y][x]==0) {
+						//만약 그 위치가 새로 세운 벽이라면 false를 가지는 변수
+						boolean flag = true;
+						
+						//해당 위치가 새로 세운 벽인지 확인함
+						for(int k=0; k<wall.length; k++) {
+							//새로 세운 벽이라면
+							if(wall[k].y==y&&wall[k].x==x) {
+								//해당 flag는 false값을 가짐
+								flag = false;
+							}
+						}
+						
+						//만약 해당 위치가 벽을 새로 세우지 않았고, 방문하지도 않았던 빈 공간이라면
+						if(flag) {
+							//해당 위치를 방문함
+							q.add(new Node(y,x));
+							v[y][x] = true;
+							
+							//바이러스가 빈 공간에 퍼진 횟수를 카운트함.
+							C++;
+						}
+					}
+				}
+			}
+		}
+		
+		//안전영역의 개수는 초기 안전영역의 개수 - 바이러스가 퍼지면서 오염된 영역의 개수 - 3(빈 공간에 벽을 세우면서 사라진 안전 영역의 개수)임
+		return Z-C-3;
+	}
+	
+	//맵에서 빈 공간인 영역 3개를 골라 벽을 세우고 BFS 탐색을 수행하는 메소드
+	public static void combinate(int[][] map, boolean[] v, int idx, int cnt, Queue virus, Node[] wall, int Z) {
+		//벽을 3개 모두 다 세웠다면
+		if(cnt==3) {
+			//바이러스를 그 상태로 바이러스가 퍼졌을때 안전 영역의 크기를 구한 뒤 최대 안전 영역의 크기보다 크다면 그것으로 갱신시킴
+			max = Math.max(max, BFS(map,virus,wall,Z));
+		}else {
+			for(int i=idx; i<v.length; i++) {
+				//벽을 세울 위치의 좌표를 얻음
+				int y = i/map[0].length;
+				int x = i%map[0].length;
+				
+				//해당 위치에 아직 벽을 세우지 않았고, 빈 공간이라면
+				if(!v[i]&&map[y][x]==0) {
+					//해당 위치에 벽을 세움
+					v[i] = true;
+					
+					//벽의 정보를 저장함
+					wall[cnt] = new Node(y,x);
+					
+					//재귀적으로 다음에 세울 벽의 위치를 구함
+					combinate(map,v,i+1,cnt+1,virus,wall, Z);
+					
+					//벽의 정보를 없던 것으로 처리함
+					wall[cnt] = null;
+					
+					//해당 위치를 방문하지 않은 것처럼 처리함
+					v[i] = false;
+				}
+			}
+		}
+	}
+
+	public static void main(String[] args) throws Exception {
+		String[] temp = br.readLine().split(" ");
+		
+		Queue<Node> virus = new LinkedList<Node>();
+		
+		int N = Integer.parseInt(temp[0]);
+		int M = Integer.parseInt(temp[1]);
+		int Z = 0, V=0;
+		int[][] map = new int[N][M];
+		
+		//맵의 정보를 입력 받음
+		for(int i=0; i<N; i++) {
+			temp = br.readLine().split(" ");
+			for(int j=0; j<map[0].length; j++) {
+				map[i][j] = Integer.parseInt(temp[j]);
+				
+				//입력 받은 위치가 벽이라면
+				if(map[i][j]==0) {
+					//초기 안전 영역의 개수를 1 증가시킴
+					Z++;
+				//입력 받은 위치가 벽이라면
+				}else if(map[i][j]==2) {
+					//바이러스의 위치를 큐에 추가함
+					virus.add(new Node(i,j));
+				}
+			}
+		}
+		
+		//현재 맵에서 0인 위치 3개를 골라 벽을 세웠을때의 안전영역을 크기를 구함
+		combinate(map, new boolean[N*M], 0, 0, virus, new Node[3], Z);
+		
+		//최대 안전영역의 크기를 출력함.
+		bw.write(max+"\n");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/14502)


문제 요구사항 : 

<pre>
해당 문제는 백트래킹을 활용하여 조합 알고리즘을 구현할 줄 아는지, 정수 값을 y, x등의 좌표로 변환할 줄 아는지,
BFS탐색의 기본 동작 원리와 구현방법을 알고 있는지 묻는 문제임.
</pre>

접근 방법 : 

<pre>
맵의 크기는 최대 8*8로 비슷한 유형의 문제와 비교했을 때 상당히 작은 편에 속하며,
벽을 새로 3개를 설치하는 모든 가능한 경우에 대하여 BFS 탐색을 수행해야 함.

벽을 새로 3개를 설치하는 경우의 수를 구하는 방법은 간단함.
백트래킹을 활용하여 중복되지 않게 1 ~ N*M-1 사이의 정수 3개를 선택하면 됨.
그렇게 선택된 정수 3개를 y, x 좌표로 변환하면 그것이 곧 새로운 벽의 좌표가 됨.
단, 선택된 3개의 좌표가 모두 빈 공간임을 보장해야 함.

정수를 좌표로 변환하는 방법은 간단함. 정수 i와 map[N][M]이 존재할 때
y좌표는 y = i / M, x좌표는 x = i % M으로 쉽게 구할 수 있음.

효율성에 관하여 말하자면, 벽을 3개를 배치한 후에 BFS탐색을 수행하고 그것이 종료되었을 때,
일일이 바이러스가 퍼지지 않은 빈 공간을 이중 for문으로 탐색할 필요가 없음.
안전영역의 개수 = 초기 안전영역의 개수 - 바이러스에 오염된 영역의 개수 - 3(빈공간에 벽을 세움으로써 사라진 안전 영역의 개수)임.
</pre>

풀이 순서 : 

<pre>
1. 맵의 정보를 입력 받음. 이때, 초기 안전영역의 개수를 카운트 함.

2. 1 ~ N*M-1 사이의 정수 중, 3개를 선택하여 좌표로 변환하되, 해당 좌표는 빈 공간이어야 함을 보장하면서 선택함.

3. 3개의 벽을 세울 좌표가 선택되었다면 BFS탐색을 수행함.

4. BFS탐색이 종료되면 안전영역의 개수는 안전영역의 개수 = 초기 안전영역의 개수 - 바이러스에 오염된 영역의 개수 - 3으로 계산함.

5. 계산된 안전영역의 개수가 기존 최대값보다 크다면 그것으로 최대값을 갱신함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/194810314-047b6d5b-dcf4-455b-af37-d4998f9fc2cb.png)