### PR TITLE
[BOJ] [DAC] [1074] [Z]

### DIFF
--- a/BOJ/DAC/1074/P-digit/main.py
+++ b/BOJ/DAC/1074/P-digit/main.py
@@ -1,0 +1,19 @@
+n, r, c = map(int, input().split())
+
+def dac(n, r, c):
+    if n == 1:
+        if r==0 and c==0:
+            return 0
+        elif r==0 and c==1:
+            return 1
+        elif r==1 and c==0:
+            return 2
+        else:
+            return 3
+    else:
+        r_q = r//(2**(n-1))
+        c_q = c//(2**(n-1))
+        temp = dac(n-1, r%(2**(n-1)), c%(2**(n-1)))
+        return (2*(r_q)+(c_q))*((2**(n-1))**2) + temp
+        
+print(dac(n, r, c))


### PR DESCRIPTION
Source URL : 
[문제](https://www.acmicpc.net/problem/1074)


문제 요구사항 : 

(2^N, 2^N)의 배열을 Z모양으로 탐색할 때, r행 c열에 도달할 때까지 거친 성분의 개수 총합


접근 방법 : 

분할정복을 통해 (2^N, 2^N) 배열을 (2^(N-1), 2^(N-1))의 배열로 분할하면서 정복


(고려사항)

1. 분할할 때 행 r과 열 c의 조정 필요


풀이 순서 : 

1. 정보 (N, r, c) 입력
2. N == 1 이면 Z모양에 맞게 값 리턴
3. N != 1 이면  거쳐 갔다고 생각할 수 있는 정사각형의 넓이를 더하고 그 때의 행과 열 값을 2^(N-1)로 나눴을 때의 나머지로 분할정복 수행
4. 모든 값을 더한 후 출력

문제 풀이 결과 : 
![image](https://user-images.githubusercontent.com/62891362/195826654-5de03b66-ae98-486f-889c-ac87745f7b99.png)


