### PR TITLE
[BOJ] [DFS] [1260] [DFS와 BFS]

### DIFF
--- a/BOJ/DFS/1260/P-digit/main.py
+++ b/BOJ/DFS/1260/P-digit/main.py
@@ -1,0 +1,51 @@
+from collections import deque
+
+
+N, M, V = map(int, input().split())
+
+dic = {}
+
+for n in range(1, N+1):
+    dic[n] = []
+
+for _ in range(M):
+    n1, n2 = map(int, input().split())
+    for _ in range(2):
+        if n2 not in dic[n1]:
+            dic[n1].append(n2)
+        n1, n2 = n2, n1
+for i in range(1, N+1):
+    dic[i] = sorted(dic[i])
+
+def bfs():
+    dq = deque()
+    chk = [False for _ in range(N+1)]
+    dq.append(V)
+    chk[V] = True
+    result = [V]
+    while dq:
+        chk_node = dq.popleft()
+        for e in dic[chk_node]:
+            if not chk[e]:
+                dq.append(e)
+                chk[e] = True
+                result.append(e)
+    print(*result, sep=' ')
+
+
+def dfs():
+    result = []
+    stk = [V]
+    chk = [False for _ in range(N+1)]
+    while stk:
+        chk_node = stk.pop()
+        if not chk[chk_node]:
+            chk[chk_node] = True
+            result.append(chk_node)
+            for e in dic[chk_node][::-1]:
+                if not chk[e]:
+                    stk.append(e)
+    print(*result, sep=' ')
+
+dfs()
+bfs()


### PR DESCRIPTION
Source URL : 
[문제](https://www.acmicpc.net/problem/1260)

문제 요구사항 : 

DFS와 BFS을 각각 수행해 탐색한 노드 순서대로 출력

접근 방법 : 

DFS, BFS 구현 후 탐색해 순서대로 결과 출력

풀이 순서 : 

1. 정점의 수 N, 간선의 수 M, 시작 정점 V 입력 받음
2. 그래프 구현 후 DFS, BFS 수행
3.  탐색한 순서대로 정점 출력

문제 풀이 결과 : 
![image](https://user-images.githubusercontent.com/62891362/195964091-08909166-8a79-43b5-888b-f618b8a2dc23.png)

