### PR TITLE
[BOJ] [BFS] [13460] [구슬 탈출2]

### DIFF
--- a/BOJ/BFS/13460/inseonyun/main.cpp
+++ b/BOJ/BFS/13460/inseonyun/main.cpp
@@ -1,0 +1,133 @@
+
+//////////////////////////////////////////////////
+// BAEKJOON: 13460_구슬 탈출2
+//////////////////////////////////////////////////
+
+#include <iostream>
+#include <queue>
+
+using namespace std;
+
+int N, M;
+char map[10][10];
+bool visited[10][10][10][10] = { false, };
+int dx[] = { -1, 0, 1, 0 };
+int dy[] = { 0, 1, 0, -1 };
+
+struct coordinate {
+	int x;
+	int y;
+};
+
+coordinate red;
+coordinate blue;
+int res = -1;
+
+void input() {
+	cin >> N >> M;
+
+	for (int i = 0; i < N; i++) {
+		for (int j = 0; j < M; j++) {
+			cin >> map[i][j];
+
+			if (map[i][j] == 'R') {
+				red.x = i;
+				red.y = j;
+			}
+			else if (map[i][j] == 'B') {
+				blue.x = i;
+				blue.y = j;
+			}
+		}
+	}
+}
+
+void bfs(int dir_x, int dir_y, coordinate &bead, int &cost) {
+	while (true) {
+		if (map[bead.x + dir_x][bead.y + dir_y] == '#' || map[bead.x][bead.y] == 'O') {
+			return;
+		}
+		cost += 1;
+		bead.x += dir_x;
+		bead.y += dir_y;
+	}
+}
+
+void solution() {
+
+	queue<pair<int, coordinate>> red_q;
+	queue<pair<int, coordinate>> blue_q;
+
+	red_q.push({ 0, red });
+	blue_q.push({ 0, blue });
+
+	visited[red.x][red.y][blue.x][blue.y] = true;
+
+	while (!red_q.empty() || !blue_q.empty()) {
+		coordinate now_red = red_q.front().second;
+		coordinate now_blue = blue_q.front().second;
+
+		int now_red_cost = red_q.front().first;
+		int now_blue_cost = blue_q.front().first;
+
+		red_q.pop();
+		blue_q.pop();
+
+		if (now_red_cost >= 10 || now_blue_cost >= 10) {
+			res = -1;
+			return;
+		}
+
+		for (int i = 0; i < 4; i++) {
+			coordinate next_red = now_red;
+			coordinate next_blue = now_blue;
+
+			int next_red_cost = 0;
+			int next_blue_cost = 0;
+			bfs(dx[i], dy[i], next_red, next_red_cost);
+			bfs(dx[i], dy[i], next_blue, next_blue_cost);
+
+			if (map[next_blue.x][next_blue.y] == 'O')
+				continue;
+			
+			if (map[next_red.x][next_red.y] == 'O') {
+				res = now_red_cost + 1;
+				return;
+			}
+
+			//  서로 같은 위치에 있다면 cost가 높은거(더 많이 이동한게 원래 뒤에 있던 것)
+			if (next_red.x == next_blue.x && next_red.y == next_blue.y) {
+				if (next_red_cost > next_blue_cost) {
+					next_red.x -= dx[i];
+					next_red.y -= dy[i];
+				}else{
+					next_blue.x -= dx[i];
+					next_blue.y -= dy[i];
+				}
+			}
+
+			if (visited[next_red.x][next_red.y][next_blue.x][next_blue.y])
+				continue;
+
+			visited[next_red.x][next_red.y][next_blue.x][next_blue.y] = true;
+			red_q.push({ now_red_cost + 1, next_red });
+			blue_q.push({ now_blue_cost + 1, next_blue });
+		}
+	}
+}
+
+void output() {
+	cout << res;
+}
+
+int main() {
+	ios::sync_with_stdio(false);
+	cin.tie(0);
+	cout.tie(0);
+
+	input();
+	solution();
+	output();
+
+	return 0;
+}


### PR DESCRIPTION
Source URL : https://www.acmicpc.net/problem/13460

문제 요구사항 : 
<pre>
  + 구슬 탈출은 직사각형 보드에 빨간 구슬과 파란 구슬을 하나씩 넣은 다음, 빨간 구슬을 구멍을 통해 빼내는 게임이다.
  + 보드의 세로 크기는 N, 가로 크기는 M이고, 편의상 1×1크기의 칸으로 나누어져 있다. 
  + 가장 바깥 행과 열은 모두 막혀져 있고, 보드에는 구멍이 하나 있다. 
  + 빨간 구슬과 파란 구슬의 크기는 보드에서 1×1크기의 칸을 가득 채우는 사이즈이고, 각각 하나씩 들어가 있다. 
  + 게임의 목표는 빨간 구슬을 구멍을 통해서 빼내는 것이다. 이때, 파란 구슬이 구멍에 들어가면 안 된다.
  + 이때, 구슬을 손으로 건드릴 수는 없고, 중력을 이용해서 이리 저리 굴려야 한다. 
  + 왼쪽으로 기울이기, 오른쪽으로 기울이기, 위쪽으로 기울이기, 아래쪽으로 기울이기와 같은 네 가지 동작이 가능하다.
</pre>

<pre>
  + 각각의 동작에서 공은 동시에 움직인다. 빨간 구슬이 구멍에 빠지면 성공이지만, 파란 구슬이 구멍에 빠지면 실패이다. 
  + 빨간 구슬과 파란 구슬이 동시에 구멍에 빠져도 실패이다.
  + 빨간 구슬과 파란 구슬은 동시에 같은 칸에 있을 수 없다. 또, 빨간 구슬과 파란 구슬의 크기는 한 칸을 모두 차지한다. 
  + 기울이는 동작을 그만하는 것은 더 이상 구슬이 움직이지 않을 때 까지이다.
</pre>

+ 보드의 상태가 주어졌을 때, 10번 이하로 빨간 구슬을 구멍을 통해 빼낼 수 있는지 구하는 프로그램을 작성하시오.

<pre>
  + 첫 번째 줄에는 보드의 세로, 가로 크기를 의미하는 두 정수 N, M (3 ≤ N, M ≤ 10)이 주어진다. 
  + 다음 N개의 줄에 보드의 모양을 나타내는 길이 M의 문자열이 주어진다. 
  + 이 문자열은 '.', '#', 'O', 'R', 'B' 로 이루어져 있다. '.'은 빈 칸을 의미하고, '#'은 공이 이동할 수 없는 장애물 또는 벽을 의미하며, 'O'는 구멍의 위치를 의미한다. 'R'은 빨간 구슬의 위치, 'B'는 파란 구슬의 위치이다.
  + 입력되는 모든 보드의 가장자리에는 모두 '#'이 있다. 구멍의 개수는 한 개 이며, 빨간 구슬과 파란 구슬은 항상 1개가 주어진다.
  + 최소 몇 번 만에 빨간 구슬을 구멍을 통해 빼낼 수 있는지 출력한다. 
  + 만약, 10번 이하로 움직여서 빨간 구슬을 구멍을 통해 빼낼 수 없으면 -1을 출력한다.
</pre>


접근 방법 :  기본적인 풀이는 [구슬 탈출](https://github.com/hs-study-group/algorithm/pull/188)과 동일하다. 단, 출력을 탈출 실패 시 -1로, 탈출 성공시 red_q의 cost를 출력하도록 하면 된다.


풀이 순서 :
1. N과 M을 입력 받고, 해당 크기만큼의 맵의 정보를 입력 받는다.
    + 이 때, 맵의 정보 해당 인덱스 값이 'R' 또는 'B' 라면 해당 좌표를 각각 red와 blue에 저장한다
2. visited의 red x, y좌표 blue x, y 좌표 = true를 하고, 각각의 queue를 생성해 좌표와 cost를 넣고 bfs 탐색을 수행한다.
3. BFS
    + 각 구슬의 좌표, cost를 queue에서 pop한 뒤, 각각의 cost 중 하나라도 10을 넘으면 res=-1을 주고 종료한다.
    + 각각의 구슬 nx ny에 초기값 각각의 구슬 좌표를 넣어주고, 벽이나 구멍을 만날 때까지 쭉 이동해야하므로,
    + while 문을 사용해서 해당 조건을 충족할 때까지 이동시킨다.
    + 각각의 구슬 nx, ny 값의 map 정보가 만약 블루가 먼저 들어갔다면 탐색 continue
    + red가 들어갔다면 res=red_q.front().first (이는 red_q의 cost이다.) 하고, bfs 종료
    + 각각의 구슬 nx ny가 같다면, cost (이동한 거리)가 높은게 다른 구슬보다 뒤에 있었던 것이므로, 해당 좌표에 -= dx, dy를 해준다.
    + 만약 visted 각각의 구슬 좌표 nx ny가 true라면 이미 방문한 것이므로, 탐색 continue
    + 아니라면 해당 좌표 visited에 true를 주고, 각각의 구슬 queue에 cost +1과 각 구슬 nx, ny 좌표를 넣어준다.
    + 이와같은 작업 반복
4. res 출력


문제 풀이 결과 : 

![image](https://user-images.githubusercontent.com/84364741/196097281-5f35a526-00ba-4bff-8060-fd7f0900afc3.png)
