### PR TITLE
[BOJ] [BFS] [1389] [케빈 베이컨의 6단계 법칙]

### DIFF
--- a/BOJ/BFS/1389/inseonyun/main.cpp
+++ b/BOJ/BFS/1389/inseonyun/main.cpp
@@ -1,0 +1,109 @@
+
+//////////////////////////////////////////////////
+// BAEKJOON: 1389_케빈 베이컨의 6단계 법칙
+//////////////////////////////////////////////////
+
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <cstring>
+#include <algorithm>
+
+using namespace std;
+
+int N, M;
+vector<int> v[101];
+bool visited[101] = { false, };
+
+struct result {
+	int cost;
+	int idx;
+};
+vector<result> res;
+
+void input() {
+	cin >> N >> M;
+
+	for (int i = 0; i < M; i++) {
+		int a, b;
+		cin >> a >> b;
+
+		v[a].push_back(b);
+		v[b].push_back(a);
+	}
+}
+
+int bfs(int now) {
+	vector<int> row[101];
+
+	visited[now] = true;
+	queue<pair<int, int>> q;
+	q.push({ now, 0 });
+
+	while (!q.empty()) {
+		int cur = q.front().first;
+		int cost = q.front().second;
+
+		q.pop();
+
+		row[cur].push_back(cost);
+
+		for (int i = 0; i < v[cur].size(); i++) {
+			int next_cur = v[cur][i];
+
+			if (!visited[next_cur]) {
+				visited[next_cur] = true;
+				q.push({ next_cur, cost + 1 });
+			}
+		}
+	}
+
+	for (int i = 1; i <= N; i++) {
+		sort(row[i].begin(), row[i].end());
+	}
+
+	int now_cost = 0;
+	for (int i = 1; i <= N; i++) {
+		if (i != now)
+			now_cost += row[i][0];
+
+	}
+
+	return now_cost;
+}
+
+void solution() {
+
+	for (int i = 1; i <= N; i++) {
+		memset(visited, false, sizeof(visited));
+		int now_node_cnt = bfs(i);
+
+		res.push_back({ now_node_cnt, i });
+	}
+}
+
+bool cmp(result a, result b) {
+	
+	if (a.cost == b.cost)
+		return a.idx < b.idx;
+
+	return a.cost < b.cost;
+}
+
+void output() {
+	sort(res.begin(), res.end(), cmp);
+	
+	cout << res[0].idx;
+}
+
+int main() {
+	ios::sync_with_stdio(false);
+	cin.tie(0);
+	cout.tie(0);
+
+	input();
+	solution();
+	output();
+
+	return 0;
+}


### PR DESCRIPTION
Source URL : https://www.acmicpc.net/problem/1389

문제 요구사항 : 
+ 케빈 베이컨의 6단계 법칙에 의하면 지구에 있는 모든 사람들은 최대 6단계 이내에서 서로 아는 사람으로 연결될 수 있다. 케빈 베이컨 게임은 임의의 두 사람이 최소 몇 단계 만에 이어질 수 있는지 계산하는 게임이다.

<pre>
  예를 들면, 전혀 상관없을 것 같은 인하대학교의 이강호와 서강대학교의 민세희는 몇 단계만에 이어질 수 있을까?
  천민호는 이강호와 같은 학교에 다니는 사이이다. 
  1. 천민호와 최백준은 Baekjoon Online Judge를 통해 알게 되었다. 
  2. 최백준과 김선영은 같이 Startlink를 창업했다. 
  3. 김선영과 김도현은 같은 학교 동아리 소속이다. 
  4. 김도현과 민세희는 같은 학교에 다니는 사이로 서로 알고 있다. 
  즉, 이강호-천민호-최백준-김선영-김도현-민세희 와 같이 5단계만 거치면 된다.
  
  케빈 베이컨은 미국 헐리우드 영화배우들 끼리 케빈 베이컨 게임을 했을때 나오는 단계의 총 합이 가장 적은 사람이라고 한다.
</pre>

+  오늘은 Baekjoon Online Judge의 유저 중에서 케빈 베이컨의 수가 가장 작은 사람을 찾으려고 한다.
+ 케빈 베이컨 수는 모든 사람과 케빈 베이컨 게임을 했을 때, 나오는 단계의 합이다.

<pre>
  예를 들어, BOJ의 유저가 5명이고, 1과 3, 1과 4, 2와 3, 3과 4, 4와 5가 친구인 경우를 생각해보자.

  1은 2까지 3을 통해 2단계 만에, 3까지 1단계, 4까지 1단계, 5까지 4를 통해서 2단계 만에 알 수 있다. 
  따라서, 케빈 베이컨의 수는 2+1+1+2 = 6이다.
  2는 1까지 3을 통해서 2단계 만에, 3까지 1단계 만에, 4까지 3을 통해서 2단계 만에, 5까지 3과 4를 통해서 3단계 만에 알 수 있다. 
  따라서, 케빈 베이컨의 수는 2+1+2+3 = 8이다.
  3은 1까지 1단계, 2까지 1단계, 4까지 1단계, 5까지 4를 통해 2단계 만에 알 수 있다. 
  따라서, 케빈 베이컨의 수는 1+1+1+2 = 5이다.
  4는 1까지 1단계, 2까지 3을 통해 2단계, 3까지 1단계, 5까지 1단계 만에 알 수 있다. 
  4의 케빈 베이컨의 수는 1+2+1+1 = 5가 된다.
  마지막으로 5는 1까지 4를 통해 2단계, 2까지 4와 3을 통해 3단계, 3까지 4를 통해 2단계, 4까지 1단계 만에 알 수 있다. 
  5의 케빈 베이컨의 수는 2+3+2+1 = 8이다.
  
  5명의 유저 중에서 케빈 베이컨의 수가 가장 작은 사람은 3과 4이다.
</pre>

+ BOJ 유저의 수와 친구 관계가 입력으로 주어졌을 때, 케빈 베이컨의 수가 가장 작은 사람을 구하는 프로그램을 작성하시오.
+ 첫째 줄에 유저의 수 N (2 ≤ N ≤ 100)과 친구 관계의 수 M (1 ≤ M ≤ 5,000)이 주어진다. 
+ 둘째 줄부터 M개의 줄에는 친구 관계가 주어진다. 친구 관계는 A와 B로 이루어져 있으며, A와 B가 친구라는 뜻이다.
+ A와 B가 친구이면, B와 A도 친구이며, A와 B가 같은 경우는 없다. 친구 관계는 중복되어 들어올 수도 있으며, 친구가 한 명도 없는 사람은 없다. 
+ 또, 모든 사람은 친구 관계로 연결되어져 있다. 사람의 번호는 1부터 N까지이며, 두 사람이 같은 번호를 갖는 경우는 없다.
+ 첫째 줄에 BOJ의 유저 중에서 케빈 베이컨의 수가 가장 작은 사람을 출력한다. 
+ 그런 사람이 여러 명일 경우에는 번호가 가장 작은 사람을 출력한다.

접근 방법 :  1부터 N까지 반복문을 돌면서 해당 노드에서 시작해서 각 노드까지의 단계를 구한다. 이 때, 그 단계는 여러 개일 수 있으므로, sorting을 해줘 단계가 낮은 것을 해당 노드까지의 단계로 선정한다.

풀이 순서 :
1. N과 M 그리고 M개의 관계를 입력 받는다.
2. 1부터 N까지 반복하여 현재 노드의 친구 관계 BFS를 수행한다.
3. BFS
    + 반복인자로 받은 노드를 queue에 시작 비용( 0 )과 함께 넣고, queue가 빌 때까지 while문을 반복한다.
    + queue에서 cur( 정점) 과 cost ( 단계 ) 를 꺼내고 row 벡터에 cur 인덱스에 해당 cost를 넣는다.
    + v (친구 관계 벡터)의 cur 인덱스의 size 만큼 for문을 반복하여 다음 정점을 구한다.
    + visted [ next_cur ] 이 false라면, true값을 넣어주고, queue에 next_cur과 cost + 1한 것을 넣고 계속 탐색한다.
    + 탐색 종료 후, row 벡터의 각각의 인덱스의 cost를 오름차순 정렬한다.
    + 이후 초기에 받은 시작 노드를 제외하고 row 벡터의 cost를 모두 더하여 return 한다.
    + return 된 값을 res에 넣는다
    + 이와 같은 작업 반복
4. res에 있는 result 구조체 ( 단계별 합과 인덱스 ) 를 단계별 합을 기준으로 또 한 번 정렬하고, 만약 같다면 인덱스를 기준으로 오름차순 정렬한다.
5. res[0].idx를 출력한다.


문제 풀이 결과 : 

![image](https://user-images.githubusercontent.com/84364741/196640297-4ec5a670-a304-4519-8e1e-7d4e72590a12.png)
