### PR TITLE
[BOJ] [SegmentTree] [1725] [히스토그램]

### DIFF
--- a/BOJ/SegmentTree/1725/Blanc_et_Noir/Main.java
+++ b/BOJ/SegmentTree/1725/Blanc_et_Noir/Main.java
@@ -1,0 +1,117 @@
+//https://www.acmicpc.net/problem/1725
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static int[] arr;
+	static int[][] tree;
+	
+	//히스토그램에서의 직사각형의 최대 크기
+	static int max = Integer.MIN_VALUE;
+	
+	//세그먼트 트리를 초기화하는 메소드
+	public static void init(int node, int start, int end) {
+		if(start==end) {
+			//해당 트리의 노드에 히스토그램의 높이와 그 인덱스를 저장함
+			tree[node][0] = arr[start];
+			tree[node][1] = start;
+			return;
+		}else {
+			int mid = (start+end)/2;
+			
+			//재귀적으로 두 자식노드에 대해서도 초기화를 수행함
+			init(node*2,start,mid);
+			init(node*2+1,mid+1,end);
+			
+			//부모노드의 높이와 인덱스는 자식 노드중 높이가 더 작은 노드의 것으로 함
+			if(tree[node*2][0]<tree[node*2+1][0]) {
+				tree[node][0] = tree[node*2][0];
+				tree[node][1] = tree[node*2][1];
+			}else {
+				tree[node][0] = tree[node*2+1][0];
+				tree[node][1] = tree[node*2+1][1];
+			}
+			return;
+		}
+	}
+	
+	//left, right 구간에 대하여 히스토그램의 최소 높이를 구함
+	public static int[] query(int node, int start, int end, int left, int right) {
+		//현재 탐색중인 구간이 탐색해야할 구간을 완전히 벗어난 경우
+		if(start>right||end<left) {
+			//높이는 MAX를 리턴하여 결과에 영향이 없도록 함
+			return new int[] {Integer.MAX_VALUE,-1};
+		//현재 탐색중인 구간이 탐색해야할 구간에 완전히 포함된 경우
+		}else if(left<=start&&end<=right) {
+			//해당 노드 정보를 리턴함
+			return tree[node];
+		//현재 탐색중인 구간이 탐색해야할 구간에 걸치는 경우
+		}else {
+			int mid = (start+end)/2;
+			
+			//두 자식노드에 대하여 쿼리를 재귀적으로 수행함
+			int[] r1 = query(node*2,start,mid,left,right);
+			int[] r2 = query(node*2+1,mid+1,end,left,right);
+			
+			//두 자식노드의 결과중 히스토그램의 높이가 더 작은 노드의 값을 리턴함
+			if(r1[0]<r2[0]) {
+				return r1;
+			}else {
+				return r2;
+			}
+		}
+	}
+	
+	//히스토그램의 높이가 최소가 되는 지점을 찾고, 그 지점을 제외한 나머지 양쪽 구간에 대해 쿼리를 재귀적으로 수행하는 메소드
+	public static void recursive(int left, int right) {
+		//left가 right보다 우측에 존재하면
+		if(left>right) {
+			//모든 탐색을 마친 것이므로 return함
+			return;
+	
+		//left right구간이 유효하다면
+		}else {
+			//해당 left right 구간에 대하여 히스토그램의 최소 높이를 구함
+			int[] r = query(1,0,arr.length-1,left,right);
+			
+			//히스토그램에서의 직사각형의 넓이를 구한후, 그것이 최대 넓이보다 크다면 그것으로 최대 넓이를 갱신함
+			max = Math.max(max,r[0] * (right-left+1));
+			
+			//히스토그램의 높이가 최소가 되는 지점을 기준으로 양쪽 구간에 대하여 재귀적으로 탐색함
+			recursive(left,r[1]-1);
+			recursive(r[1]+1,right);
+			return;
+		}
+	}
+	
+	public static void main(String[] args) throws Exception {
+		int N = Integer.parseInt(br.readLine());
+		
+		//세그먼트 트리의 사이즈는 N을 기준으로 아래와 같이 계산할 수 있음 
+		final int TREE_SIZE = 1<<((int) Math.ceil(Math.log(N)/Math.log(2))+1);
+		arr = new int[N];
+		tree = new int[TREE_SIZE][2];
+		
+		//히스토그램의 높이를 입력받음
+		for(int i=0; i<N; i++) {
+			arr[i] = Integer.parseInt(br.readLine());
+		}
+		
+		//세그먼트 트리를 초기화 함
+		init(1,0,N-1);
+		
+		//재귀적으로 히스토그램의 높이가 최소가 되는 지점을 찾고 그때의 넓이를 구함
+		recursive(0,N-1);
+		
+		//최대 넓이를 출력함
+		bw.write(max+"\n");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/1725)


문제 요구사항 : 

<pre>
해당 문제는 느리게 갱신되는 세그먼트 트리에 대해 알고 있는지, 구현방법을 알고 있는지,
느리게 갱신 되는 세그먼트 트리와 세그먼트 트리의 차이를 알고 있는지를 묻는 문제임.
</pre>

접근 방법 : 

<pre>
기본적으로 세그먼트 트리는 특정 구간에 대한 특정 값을 구할 때 log(N)만큼의 시간 복잡도를 가짐.
그러한 동작을 N번 수행하면 Nlog(N)만큼의 시간 복잡도가 필요함.

특정 값 하나를 갱신할 때 사용하는 갱신 메소드 또한 log(N)만큼의 시간 복잡도를 가지며, 
N개를 갱신해야 한다면 Nlog(N)만큼의 시간 복잡도가 필요함.

그런데, N개의 값을 갱신하는 작업을 N번 수행한다면, N^2log(N)만큼의 시간 복잡도가 필요하게 됨.
이는 느리게 갱신되는 세그먼트 트리를 사용하면 쉽게 해결할 수 있음.

느리게 갱신되는 세그먼트 트리의 기본원리는 아래와 같음.
어떤 부모 노드의 값을 갱신해야 할 때, 해당 노드의 자식 노드에서 값을 갱신하고,
두 자식 노드의 값을 적절히 조합하여 부모 노드의 값을 최종적으로 계산하기보다는,

즉, 자식 노드가 갱신될때까지 부모노드의 갱신을 미루기 보다는
부모 노드의 값을 선제적으로 먼저 갱신하고, 자식 노드에 대한 갱신은 나중으로 미루겠다는 것이 기본 원리임.

다시 말해서 L : R 구간의 값들에 V만큼을 더하고자 한다면, 그들의 리프노드까지 탐색하여 리프노드의 값을 V만큼 증가시키고
그 리프노드의 부모노드의 두 자식노드의 합으로 갱신하기 보다는,

R - L + 1개의 리프노드들을 V만큼 증가시켰다고 가정하고, L : R구간에 대한 정보를 가진 부모 노드의 값을
(R - L + 1) * V만큼 증가시킴으로써 자식노드까지 굳이 탐색하지 않고 시간을 절약하는 것임.

이러한 동작 덕분에 L : R구간의 값을 V만큼 증가시키는데 필요한 시간 복잡도를 Nlog(N) -> log(N)으로 획기적으로 줄일 수 있음.



히스토그램내에 가장 큰 직사각형의 넓이를 구하는 데에 느리게 갱신되는 세그먼트 트리를 활용하는 방법은 아래와 같음.
히스토그램내에 가장 큰 직사각형의 넓이는 직사각형의 높이와 관련이 있음.
1 ~ N 구간에서 가장 크기가 작은 히스토그램 막대의 높이가 H라면, 그 구간에서의 직사각형의 넓이는 (N - 1 + 1)*H임.

그 이후 두 번째로 크기가 작은 히스토그램 막대의 높이는 가장 크기가 작은 히스토그램 막대를 제외한
나머지 두 구간에 대해 쿼리를 수행하여 구할 수 있음.

1 ~ N구간에서 가장 크기가 작은 히스토그램의 막대의 인덱스가 X라면, 
1 ~ N구간에서 두 번째로 작은 히스토그램 막대는 1 ~ X - 1 구간과 X + 1 ~ N구간에서의 가장 작은 히스토그램 막대가 됨.

1 ~ X - 1 구간에서 가장 작은 막대 높이가 H1, X + 1 ~ N 구간에서 가장 작은 막대 높이가 H2일때,
직사각형의 넓이는 각각 (X - 1)*H1과 (N- X)*H2가 됨.

그렇게 이분탐색으로 직사각형들의 넓이를 구하며 최대 넓이를 구하면 됨.
</pre>

풀이 순서 : 

<pre>
1. 배열 및 느리게 갱신되는 세그먼트 트리를 초기화 함.

2. 전체 구간에 대하여 가장 작은 막대의 높이를 구하고 이를 토대로 넓이를 구함.

3. 가장 작은 막대를 기준으로 양 구간으로 나누어 2번 과정을 반복함.

4. 가장 큰 직사각형의 넓이를 출력함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/197809276-a149c09b-162e-4dc6-b721-e53a0bf72ace.png)