### PR TITLE
[BOJ] [SegmentTree] [6549] [히스토그램에서 가장 큰 직사각형]

### DIFF
--- a/BOJ/SegmentTree/6549/Blanc_et_Noir/Main.java
+++ b/BOJ/SegmentTree/6549/Blanc_et_Noir/Main.java
@@ -1,0 +1,135 @@
+//https://www.acmicpc.net/problem/6549
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static long[] arr;
+	static long[][] tree;
+	
+	//두 쿼리의 결과에 대하여 더 작은 높이를 갖는 쿼리 결과를 리턴하는,
+	//두 쿼리의 결과의 높이가 동일하다면 더 작은 인덱스를 갖는 결과를 리턴하는 메소드
+	public static long[] process(long[] r1, long[] r2) {
+		if(r1[0]<r2[0]) {
+			return r1;
+		}else if(r1[0]>r2[0]) {
+			return r2;
+		}else {
+			if(r1[1]<=r2[1]) {
+				return r1;
+			}else {
+				return r2;
+			}
+		}
+	}
+	
+	//세그먼트 트리를 초기화하는 메소드
+	public static void init(int node, int start, int end) {
+		//만약 리프노드라면
+		if(start==end) {
+			//해당 트리의 노드에는 해당 인덱스에 대응되는 높이와 인덱스 값을 저장함 
+			tree[node][0] = arr[start];
+			tree[node][1] = start;
+			return;
+		//만약 리프노드가 아니라면
+		}else {
+			int mid = (start+end)/2;
+			
+			//두 자식노드에 대하여 초기화를 재귀적으로 수행함
+			init(node*2,start,mid);
+			init(node*2+1,mid+1,end);
+			
+			//부모 노드는 자식노드중 더 작은 높이 값을 갖는 노드의 값으로 함
+			//두 자식노드의 높이가 동일하다면 인덱스가 더 작은 노드의 것으로 함
+			tree[node] = process(tree[node*2],tree[node*2+1]);
+			return;
+		}
+	}
+	
+	//left, right 구간에 대하여 최소높이와 그 인덱스를 반환하는 메소드
+	public static long[] query(int node, int start, int end, int left, int right) {
+		//현재 탐색중인 구간이 탐색할 구간에서 완전히 벗어났다면
+		if(start>right||end<left) {
+			//쿼리의 결과에 영향을 주지 않도록 MAX_VALUE를 높이로 설정함
+			return new long[] {Long.MAX_VALUE,-1};
+		//현재 탐색중인 구간이 탐색할 구간에 완전히 포함되는 경우
+		}else if(left<=start&&end<=right) {
+			//해당 트리의 노드를 리턴함
+			return tree[node];
+		//현재 탐색중인 구간이 탐색할 구간에 걸치는 경우
+		}else {
+			int mid = (start+end)/2;
+			
+			//두 자식 노드에 대하여 쿼리를 재귀적으로 수행한 후, 그 결과값중 높이가 더 작은 쿼리 결과를 리턴함
+			//만약 높이가 동일하다면, 더 작은 인덱스 값을 갖는 쿼리의 결과를 리턴함 
+			return process(query(node*2,start,mid,left,right),query(node*2+1,mid+1,end,left,right));
+		}
+	}
+	
+	//재귀적으로 left, right 구간에 대하여 최소높이와 그 인덱스를 구한 후
+	//그때의 넓이의 최대값을 리턴하는 메소드
+	public static long recursive(int left, int right) {
+		//left가 right보다 크다면
+		if(left>right) {
+			//탐색할 필요가 없으며, 전체 결과에 영향을 주지 않도록 음수를 리턴함
+			return -1;
+		//left, right의 값이 정상적이면
+		}else {
+			//left, right 구간에서의 최소높이와 그 인덱스를 얻음
+			long[] r = query(1,0,arr.length-1,left,right);
+			
+			//그때의 직사각형 넓이를 구함
+			long extent = (right-left+1)*r[0];
+			
+			//현재 계산한 직사각형 넓이와 최소높이가 되는 인덱스를 기준으로 양쪽으로 분할하여 구해낸 최대 넓이중
+			//가장 큰 값을 결과값으로 하여 리턴함
+			return getMax(extent,recursive(left,(int)r[1]-1),recursive((int)r[1]+1,right));
+		}
+	}
+	
+	//e1, e2, e3 넓이중 가장 큰 값을 리턴하는 메소드
+	public static long getMax(long e1, long e2, long e3) {
+		long[] arr = {e1,e2,e3};
+		Arrays.sort(arr);
+		return arr[2];
+	}
+	
+	public static void main(String[] args) throws Exception {
+		
+		while(true) {
+			String[] temp = br.readLine().split(" ");
+			int N = Integer.parseInt(temp[0]);
+			
+			//만약 입력이 0이라면
+			if(N==0) {
+				//더이상 테스트를 수행하지 않음
+				break;
+			//입력이 0이 아니라면
+			}else {
+				//배열과 세그먼트 트리를 선언함
+				arr = new long[N];
+				tree = new long[4*N][2];
+				
+				//배열에 히스토그램 높이를 입력 받음
+				for(int i=0; i<N; i++) {
+					arr[i] = Integer.parseInt(temp[i+1]);
+				}
+				
+				//세그먼트 트리를 초기화 함
+				init(1,0,N-1);
+				
+				//0 ~ N-1 구간에서의 직사각형 최대 크기를 출력함
+				bw.write(recursive(0,N-1)+"\n");
+			}
+		}
+		
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/6549)


문제 요구사항 : 

<pre>
해당 문제는 느리게 갱신되는 세그먼트 트리에 대해 알고 있는지, 구현방법을 알고 있는지,
느리게 갱신 되는 세그먼트 트리와 세그먼트 트리의 차이를 알고 있는지를 묻는 문제임.
</pre>

접근 방법 : 

<pre>
기본적으로 세그먼트 트리는 특정 구간에 대한 특정 값을 구할 때 log(N)만큼의 시간 복잡도를 가짐.
그러한 동작을 N번 수행하면 Nlog(N)만큼의 시간 복잡도가 필요함.

특정 값 하나를 갱신할 때 사용하는 갱신 메소드 또한 log(N)만큼의 시간 복잡도를 가지며, 
N개를 갱신해야 한다면 Nlog(N)만큼의 시간 복잡도가 필요함.

그런데, N개의 값을 갱신하는 작업을 N번 수행한다면, N^2log(N)만큼의 시간 복잡도가 필요하게 됨.
이는 느리게 갱신되는 세그먼트 트리를 사용하면 쉽게 해결할 수 있음.

느리게 갱신되는 세그먼트 트리의 기본원리는 아래와 같음.
어떤 부모 노드의 값을 갱신해야 할 때, 해당 노드의 자식 노드에서 값을 갱신하고,
두 자식 노드의 값을 적절히 조합하여 부모 노드의 값을 최종적으로 계산하기보다는,

즉, 자식 노드가 갱신될때까지 부모노드의 갱신을 미루기 보다는
부모 노드의 값을 선제적으로 먼저 갱신하고, 자식 노드에 대한 갱신은 나중으로 미루겠다는 것이 기본 원리임.

다시 말해서 L : R 구간의 값들에 V만큼을 더하고자 한다면, 그들의 리프노드까지 탐색하여 리프노드의 값을 V만큼 증가시키고
그 리프노드의 부모노드의 두 자식노드의 합으로 갱신하기 보다는,

R - L + 1개의 리프노드들을 V만큼 증가시켰다고 가정하고, L : R구간에 대한 정보를 가진 부모 노드의 값을
(R - L + 1) * V만큼 증가시킴으로써 자식노드까지 굳이 탐색하지 않고 시간을 절약하는 것임.

이러한 동작 덕분에 L : R구간의 값을 V만큼 증가시키는데 필요한 시간 복잡도를 Nlog(N) -> log(N)으로 획기적으로 줄일 수 있음.



히스토그램내에 가장 큰 직사각형의 넓이를 구하는 데에 느리게 갱신되는 세그먼트 트리를 활용하는 방법은 아래와 같음.
히스토그램내에 가장 큰 직사각형의 넓이는 직사각형의 높이와 관련이 있음.
1 ~ N 구간에서 가장 크기가 작은 히스토그램 막대의 높이가 H라면, 그 구간에서의 직사각형의 넓이는 (N - 1 + 1)*H임.

그 이후 두 번째로 크기가 작은 히스토그램 막대의 높이는 가장 크기가 작은 히스토그램 막대를 제외한
나머지 두 구간에 대해 쿼리를 수행하여 구할 수 있음.

1 ~ N구간에서 가장 크기가 작은 히스토그램의 막대의 인덱스가 X라면, 
1 ~ N구간에서 두 번째로 작은 히스토그램 막대는 1 ~ X - 1 구간과 X + 1 ~ N구간에서의 가장 작은 히스토그램 막대가 됨.

1 ~ X - 1 구간에서 가장 작은 막대 높이가 H1, X + 1 ~ N 구간에서 가장 작은 막대 높이가 H2일때,
직사각형의 넓이는 각각 (X - 1)*H1과 (N- X)*H2가 됨.

그렇게 이분탐색으로 직사각형들의 넓이를 구하며 최대 넓이를 구하면 됨.
</pre>

[유사한 문제 URL](https://github.com/hs-study-group/algorithm/pull/211)

풀이 순서 : 

<pre>
1. 배열 및 느리게 갱신되는 세그먼트 트리를 초기화 함.

2. 전체 구간에 대하여 가장 작은 막대의 높이를 구하고 이를 토대로 넓이를 구함.

3. 가장 작은 막대를 기준으로 양 구간으로 나누어 2번 과정을 반복함.

4. 가장 큰 직사각형의 넓이를 출력함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/198268116-fef0fd54-aa31-47ea-b2c4-280a4ec595da.png)