### PR TITLE
[PGS] [DFS] [모두 0으로 만들기]

### DIFF
--- a/PGS/DFS/모두-0으로-만들기/Blanc_et_Noir/Solution.java
+++ b/PGS/DFS/모두-0으로-만들기/Blanc_et_Noir/Solution.java
@@ -1,0 +1,70 @@
+import java.util.*;
+
+class Solution {
+    public static long answer;
+    
+    public static long DFS(ArrayList<ArrayList<Integer>> graph,boolean[] v,int[] a, int idx){
+        long sum = a[idx];
+        long cnt = 0;
+        
+        //부모노드에 대하여 자식노드를 탐색함
+        for(int i=0; i<graph.get(idx).size(); i++){
+            int next = graph.get(idx).get(i);
+            
+            //인접한 자식노드에 방문한 적이 없다면
+            if(!v[next]){
+            	//자식노드를 방문한 것으로 처리함
+                v[next] = true;
+                
+                //자식 노드에 대하여 재귀적으로 탐색을 수행함
+                long val = DFS(graph, v, a, next);
+                
+                //부모노드를 기준으로 재귀탐색한 이후 얻은 결과값의 절대값을 누적하여 더함, 이는 이동하는데 필요한 비용임
+                cnt += Math.abs(val);
+                
+                //재귀적으로 얻은 합의 결과만큼 이동해야 하므로 누적하여 계산함
+                //가령 현재 노드와 인접한 자식 노드가 -3, 2, 4의 값을 가지고 있다면
+                //자식 노드들의 값을 부모노드로 옮기는데 필요한 비용 cnt = (3 + 2 + 4)이며
+                //부모노드가 자신의 부모노드에게 값을 전달하는데 필요한 비용 sum = (-3 + 2 + 4)임
+                sum += val;
+            }
+        }
+
+        //cnt만큼의 비용을 소모하여 자식노드의 값을 부모노드로 이동시킴
+        answer += cnt;
+        
+        //부모노드가 자신의 부모노드에게 전달해야할 값은 절대값을 고려하지 않은 단순 누적합만큼을 전달해야함
+        return sum;
+    }
+    
+    public long solution(int[] a, int[][] edges) {
+        answer = 0;
+        
+        //간선 정보를 저장받을 이중 어레이리스트 선언
+        ArrayList<ArrayList<Integer>> graph = new ArrayList<ArrayList<Integer>>();
+        long sum = 0;
+        
+        //간선정보를 입력받을 리스트 초기화
+        for(int i=0; i<a.length; i++){
+            graph.add(new ArrayList<Integer>());
+            sum += a[i];
+        }
+        
+        //간선정보를 입력받음
+        for(int i=0; i<edges.length; i++){
+            graph.get(edges[i][0]).add(edges[i][1]);
+            graph.get(edges[i][1]).add(edges[i][0]);
+        }
+        
+        //만약 모든 값들의 합이 0이 아니라면, 절대로 0을 만들 수 없다는 의미이므로 -1을 리턴함
+        if(sum!=0){
+            return -1;
+        //만약 모두 합하여 0으로 만들수 있다면
+        }else{
+        	//첫번째 간선의 정점중 하나를 기준 정점으로 삼아서 모두 해당 정점으로 값을 전달하도록 함
+            DFS(graph,new boolean[a.length], a, edges[0][0]);
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://school.programmers.co.kr/learn/courses/30/lessons/76503)


문제 요구사항 : 

<pre>
해당 문제는 DFS탐색으로 문제를 해결할 줄 아는지 묻는 문제임.
</pre>

접근 방법 : 

<pre>
해당 문제에서 가장 중요한 사실은, 어떤 노드든 간에  하나의 노드를 루트 노드로 설정하고,
나머지 노드에서 루트 노드로 값을 전달하면 그 결과는 항상 동일하다는 것임.

편의상 0번 노드를 루트 노드로 설정하고, DFS탐색을 통해 리프노드까지 이동한 이후,
리프노드부터 재귀적으로 자신의 부모노드에게 값을 전달하면서 동시에 그 비용을 계산하면 됨.

어떤 노드에 V값이 존재한다면, 부모노드에게 전달하는데 필요한 비용은 V의 절댓값 만큼이며
부모노드가 여러 자식노드로부터 받은 값을 합하는 과정은 자신이 원래 가지고 있던 값과
자식노드로부터 받은 값들을 합한 값을 구하여 그 절댓값을 재귀적으로 자신의 부모에게 재전달 하면 됨.

그러나 애초에 모든 노드가 가진 값들의 합이 0이 아니라면 문제를 절대로 해결할 수 없으므로 이를 잘 고려해야 함.
</pre>

풀이 순서 : 

<pre>
1. 모든 노드들에 대하여 해당 노드가 가진 값들의 합이 0이 아니라면 그 즉시 -1을 리턴함.

2. 루트 노드를 0번 노드로 설정하고 DFS탐색을 수행하여 리프 노드까지 진입함.

3. 리프 노드는 자신이 가진 값을 V라고 했을때, V를 부모 노드에게 전달하고, V의 절대값을 비용으로 계산하여 누적합을 구함.

4. 부모 노드는 자식들로부터 전달받은 값과 자신이 원래 가지고있던 값을 합한 결과를 V로 설정하고
   V값을 자신의 부모에게 전달하고, V의 절대값을 비용으로 계산하여 누적합을 구함.

5. 최종적으로 계산된 비용을 리턴함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/198673228-0947c29b-b48b-434f-ae69-02c77ad5da4c.png)