### PR TITLE
[PGS] [BFS] [지형 이동]

### DIFF
--- a/PGS/BFS/지형-이동/Blanc_et_Noir/Solution.java
+++ b/PGS/BFS/지형-이동/Blanc_et_Noir/Solution.java
@@ -1,0 +1,111 @@
+//https://school.programmers.co.kr/learn/courses/30/lessons/62050
+
+import java.util.*;
+
+//y, x좌표 및 격자칸의 높이 v, 높이의 차이 c를 저장할 노드 클래스 선언
+class Node{
+    int y, x, v, c;
+    Node(int y, int x, int v, int c){
+        this.y = y;
+        this.x = x;
+        this.v = v;
+        this.c = c;
+    }
+}
+
+class Solution {
+    public static boolean[][] v;
+    public static PriorityQueue<Node> pq;
+    
+    //주어진 맵에 대하여 node부터 높이차이가 height이하인 지역을 방문하고
+    //같은 그룹으로 이어질 수 없는 아직 방문하지 않은 위치중 가장 작은 높이 차이를 갖는 위치를 반환하는 메소드
+    public static Node BFS(int[][] land, Node node, int height){
+        int[][] dist = {{-1,0},{1,0},{0,-1},{0,1}};
+        
+        //node부터 BFS탐색을 수행할 수 있도록 큐에 추가하고 방문처리함
+        Queue<Node> q = new LinkedList<Node>();
+        q.add(node);
+        v[node.y][node.x] = true;
+        
+        while(!q.isEmpty()){
+            Node n = q.poll();
+            
+            //상하좌우 4방향에 대하여
+            for(int i=0; i<dist.length; i++){
+                int y = n.y + dist[i][0];
+                int x = n.x + dist[i][1];
+                
+                //이동하고자 하는 위치가 맵의 범위를 벗어나지 않고, 방문한 적도 없다면
+                if(y>=0&&y<land.length&&x>=0&&x<land[0].length&&!v[y][x]){
+                	//해당 위치와의 높이 차이가 height이하일때
+                    if(Math.abs(n.v-land[y][x])<=height){
+                    	//같은 그룹으로 이어질 수 있으므로 방문함
+                        v[y][x] = true;
+                        q.add(new Node(y,x,land[y][x], 0));
+                    //해당 위치와의 높이 차이가 height보다 크다면
+                    }else{
+                    	//1. 같은 그룹이면서 height보다 높이 차이가 큰 경우
+                    	//2. 다른 그룹이면서 height보다 높이 차이가 큰 경우 두 가지 경우가 존재함
+                    	//일단 높이 차이의 절대값이 작은 순서대로 우선순위 큐에 추가함
+                        pq.add(new Node(y,x,land[y][x],Math.abs(n.v-land[y][x])));
+                    }
+                }
+            }
+        }
+        
+        //우선순위 큐가 비어있지 않다면
+        while(!pq.isEmpty()){
+            Node n = pq.poll();
+            
+            //만약 방문한 적이 없는 위치라면, 다른 그룹이면서 height보다 높이 차이가 큰 경우이므로
+            //해당 위치를 리턴함
+            if(!v[n.y][n.x]){
+                return n;
+            }
+        }
+        
+        //더이상 다른 그룹이 없다면 null을 리턴함
+        return null;
+    }
+    
+    public int solution(int[][] land, int height) {
+        int answer = 0;
+        v = new boolean[land.length][land[0].length];
+        
+        //우선순위큐는 사다리를 설치하는데 필요한 비용이 더 적은 노드가 먼저 반환되도록 함
+        pq = new PriorityQueue<Node>(new Comparator<Node>(){
+           @Override
+            public int compare(Node n1, Node n2){
+                if(n1.c<n2.c){
+                    return -1;
+                }else if(n1.c>n2.c){
+                    return 1;
+                }else{
+                    return 0;
+                }
+            }
+        });
+        
+        //편의상 0,0에서부터 BFS탐색을 수행함
+        Node n = new Node(0,0,land[0][0],0);
+        
+        while(true){
+            
+        	//BFS 탐색을 수행함
+            n = BFS(land,n,height);
+ 
+            //BFS 탐색의 결과가 null이 아니라면
+            if(n!=null){
+            	//그 결과는 가장 적은비용으로 다른 그룹과 연결될 수 있는 사다리 설치 위치와 그 비용을 가지고 있으며
+            	//그 비용을 결과값에 누적하여 더함
+                answer+=n.c;
+            //BFS 탐색의 결과가 null이라면
+            }else{
+            	//BFS 탐색 반복을 종료함
+                break;
+            }
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://school.programmers.co.kr/learn/courses/30/lessons/62050)


문제 요구사항 : 

<pre>
해당 문제는 BFS 탐색의 기본 원리 및 구현 방법을 알고 있는지를 묻는 문제임.
</pre>

접근 방법 : 

<pre>
주어진 2차원 맵에서 서로 같은 그룹에 포함되는 지역은 아래와 같은 방식으로 쉽게 구할 수 있음.
(1) 현재 탐색중인 위치의 값 V와 인접한 위치의 값 H에 대하여, abs( V - H ) <= height를 만족하면 됨.

서로 다른 그룹에 포함되는 지역 또한 아래와 같은 방식으로 쉽게 구할 수 있음.
(2) 현재 탐색중인 위치의 값 V와 인접한 위치의 값 H에 대하여, abs( V - H ) > height를 만족하면 됨.

서로 다른 그룹에 속하는 위치를 BFS탐색으로 탐색하게 되는 경우에는 그 높이 차이를 계산하여
우선순위 큐에 해당 지역의 위치와 그 높이 차이의 절대값을 저장하고,
다음 BFS탐색은 우선순위 큐에서 꺼낸 노드부터 다시 BFS탐색을 수행하면 됨.

그런데 중요한 것은, 같은 그룹임에도 서로 height보다 큰 차이를 갖는 경우가 있을 수 있다는 것임.

[참고 이미지 1]을 확인해보면 빨간 직사각형 범위에 포함된 두 숫자는 서로 같은 노란색 그룹에 속하지만
높이의 차이가 4이며, height인 3보다도 크기 때문에 (1)의 조건을 만족하지 않음에도 같은 그룹에 포함된 것을 알 수 있음.

따라서 우선순위 큐에 들어있는 노드들이 BFS탐색중이었던 그룹과 같은 그룹인 경우가 있을 수 있으며
자신이 탐색하고 있던 그룹과 다른 그룹 중에서 우선순위 큐에서 가장 먼저 얻어지는 위치부터 BFS탐색을 수행해야 함.

이때, 자신이 탐색중인 그룹과 같은 그룹인지는 방문여부를 확인하면 알 수 있음.
방문한 적이 있는 위치라면 height보다 큰 높이 차이를 가지고 있다 하더라도 같은 그룹이며,
방문한 적이 없는 위치라면 height보다 큰 높이 차이를 가진 다른 그룹임.
</pre>

![image](https://user-images.githubusercontent.com/83106564/199269745-7c3fe7be-8c00-424f-83fe-959077d75b09.png)
`[참고 이미지 1]`

풀이 순서 : 

<pre>
1. BFS탐색을 0,0위치부터 시작하되, 탐색은 높이 차이가 height이하인 경우에만 진행함.

2. 만약 높이차이가 height보다 큰 위치를 탐색하게 되는 경우 같은 그룹일 수도, 다른 그룹일 수도 있으므로
   그 위치와 높이 차이의 절대값을 우선순위 큐에 저장함.

3. BFS탐색 종료시에 우선순위 큐에서 가장 작은 높이 차이의 절대값을 갖는 노드를 하나 얻되,
   해당 위치에 방문한 적이 없는 노드를 얻음. (BFS 탐색을 수행하던 그룹과는 다른 그룹임)

4. 우선순위 큐에서 얻은 노드의 절대값을 정답 변수에 누적하여 더하고, 해당 위치부터 다시 BFS 탐색을 수행함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/199268728-d6331b79-2a57-4ef7-ab7b-5c813f510222.png)