### PR TITLE
[SWEA] [ETC] [12368] [24시간]

### DIFF
--- a/SWEA/D3/12368/inseonyun/SWEA_12368.cpp
+++ b/SWEA/D3/12368/inseonyun/SWEA_12368.cpp
@@ -1,0 +1,30 @@
+
+//////////////////////////////////////////////////
+// SWEA : 12368_24시간
+//////////////////////////////////////////////////
+
+#include <iostream>
+
+using namespace std;
+
+int main() {
+	ios::sync_with_stdio(false);
+	cin.tie(0);
+	cout.tie(0);
+
+	int TC;
+	cin >> TC;
+
+	for (int test_case = 1; test_case <= TC; test_case++) {
+		int A, B;
+		cin >> A >> B;
+
+		int sumTime = A + B;
+		if (sumTime >= 24)
+			sumTime = sumTime % 24;
+
+		cout << "#" << test_case << " " << sumTime << "\n";
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Source URL : [SWEA : 12368_24시간](https://swexpertacademy.com/main/code/problem/problemDetail.do?problemLevel=3&contestProbId=AXsEBlLqedsDFARX&categoryId=AXsEBlLqedsDFARX&categoryType=CODE&problemTitle=&orderBy=FIRST_REG_DATETIME&selectCodeLang=ALL&select-1=3&pageSize=10&pageIndex=2)


문제 요구사항 : 
+   하루는 24시간이다. 24시간제 시계에서는 하루가 자정에서 시작해서 다음 날 자정에서 끝나며, 자정에서부터 지금까지 흐른 시간을 기준으로 시각을 표기한다. 
+ 예를 들어, 지금이 오후 8시라면 “20시”와 같은 꼴로 표현할 수 있다. 자정을 표기하는 유일한 방법은 “0시”임에 유의하라.
+ 지금은 자정에서부터 정확히 A시간이 지났다. 앞으로 정확히 B시간이 더 지난다면, 24시간제 시계에서 그 때는 몇 시일까?

[입력]
+ 첫 번째 줄에 테스트 케이스의 수 T가 주어진다.
+ 각 테스트 케이스의 첫 번째 줄에는 두 개의 정수 A, B (0 ≤ A, B ≤ 23)이 공백 하나를 사이로 두고 순서대로 주어진다.

[출력]
+ 각 테스트 케이스마다, 현재 A시인 상황에서 앞으로 B시간이 지나면 몇 시가 되는지를 출력한다.


접근 방법 :  
+ A라는 시간일 때, B 시간 뒤의 시간은 몇 시간인지 구하는 문제이다.
+ A  + B를 구하고, 이 값이 24 이상이면, 24로 나눈 나머지를 출력하면 된다.


풀이 순서 :
1. TC를 입력 받고 해당 TC만큼 반복한다.
2. A와 B를 입력 받고, sumTime 변수에 A와 B를 더한 값을 넣는다.
3. sumTime 값이 24 이상이라면, 24로 나눈 나머지를 sumTime에 넣는다.
4. 출력 조건에 맞게 출력 후 이와 같은 작업 반복


문제 풀이 결과 : 

![image](https://user-images.githubusercontent.com/84364741/201527771-cb21c11b-5286-45cd-912f-4939138ab72b.png)
