### PR TITLE
[PGS] [Deque] [구명보트]

### DIFF
--- a/PGS/Deque/구명보트/Blanc_et_Noir/Solution.java
+++ b/PGS/Deque/구명보트/Blanc_et_Noir/Solution.java
@@ -1,0 +1,42 @@
+import java.util.*;
+
+class Solution {
+    
+    public int solution(int[] people, int limit) {
+        int answer = 0;
+        
+        Deque<Integer> dq = new LinkedList<Integer>();
+        
+        //사람을 몸무게순으로 오름차순 정렬함
+        Arrays.sort(people);
+        
+        //덱에 사람을 몸무게 순으로 추가함
+        for(int n : people){
+            dq.add(n);
+        }
+        
+        while(!dq.isEmpty()){
+        	//덱에 2명이상의 사람이 있을때
+            if(dq.size()>=2){
+            	//가장 몸무게가 작은 사람과 큰 사람의 무게의 합이 limit이하라면
+                if(dq.peekFirst()+dq.peekLast()<=limit){
+                	//두 사람을 모두 덱에서 제거함
+                    dq.pollFirst();
+                    dq.pollLast();
+                //limit보다 크다면
+                }else{
+                	//몸무게가 큰 사람은 절대로 다른사람과 구명보트를 공유할 수 없으므로 혼자서 구명보트에 타도록 함
+                    dq.pollLast();
+                }
+            //덱에 1명의 정보만 존재하면
+            }else{
+            	//해당 인원은 혼자 구명보트를 탑승함
+                dq.pollLast();
+            }
+            //구명보트 사용 개수를 1 증가시킴
+            answer++;
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://school.programmers.co.kr/learn/courses/30/lessons/42885)


문제 요구사항 : 

<pre>
해당 문제는 Deque 자료구조를 활용할 줄 아는지 묻는 문제다.
</pre>

접근 방법 : 

<pre>
해당 문제는 사람의 수가 최대 50000이므로 O(N^2)의 시간복잡도를 갖는 알고리즘으로는 해결할 수 없다.

몸무게가 가장 큰 사람은 구명보트에 자기 자신밖에 들어갈 수 없을 수도 있다.
또는, 정말 조금의 하중 여유가 남아서 몸무게가 가장 적은 사람과 같이 탈 수도 있다.

몸무게가 가장 큰 사람이 몸무게가 가장 작은 사람과 합승 할 수 없다면,
몸무게가 가장 큰 사람은 몸무게가 두 번째라 가장 작은 사람과도 당연히 합승할 수 없다.

가장 좋은 해결방법은 주어진 limit를 꽉 채워서 사람을 짝지어 구명보트에 태우는 것이지만,
해당 문제에서 구명보트에 탑승할 수 있는 사람의 수를 단 "2명"으로 한정지었기에,
가장 몸무게가 큰 사람, 가장 몸무게가 작은 사람, 2번째로 가장 몸무게가 작은 사람 이렇게 3명을 태울 필요가 없다.

따라서, 상식적으로 생각했을때 ,몸무게가 가장 큰 사람을 몸무게가 가장 작은 사람과 합승시켜야
구명보트의 수를 최소한으로 줄일 수 있게된다.

ArrayList의 경우 remove() 연산이 O(N)만큼의 시간복잡도를 가지므로,
결과적으로 O(N^2)의 시간복잡도를 갖는 알고리즘을 사용하게 된다.

아직 구명보트에 타지 못한 몸무게가 가장 큰 사람과 가장 작은 사람을 O(1)으로 얻는 방법은
Deque에 사람들의 정보를 저장하고, 몸무게를 기준으로 오름차순 정렬한 후에, 맨 앞과 맨 뒤의 노드를 하나씩 얻어
구명보트에 합승시킬 수 있을지 없을지를 판단하면 된다.
</pre>

풀이 순서 : 

<pre>
1. 사람들의 몸무게 정보를 Deque에 추가함.

2. Deque를 오름차순 정렬함.

3. 가장 몸무게가 큰 사람과 작은 사람의 무게 합이 limit보다 작거나 같다면 하나의 보트에 둘을 합승시킴.

4. limit보다 크다면 몸무게가 가장 큰 사람 혼자만 구명보트에 탑승시킴.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/201528091-f364cbee-7fe7-4cb0-bc99-42b57d59af98.png)