### PR TITLE
[PGS] [BruteForce] [전력망을 둘로 나누기]

### DIFF
--- a/PGS/BruteForce/전력망을-둘로-나누기/Blanc_et_Noir/Solution.java
+++ b/PGS/BruteForce/전력망을-둘로-나누기/Blanc_et_Noir/Solution.java
@@ -1,0 +1,72 @@
+import java.util.*;
+
+class Solution {
+	//하나의 간선에 포함된 두 정점 v1, v2에 대하여, v1과 v2의 간선을 제거하고
+	//v1과 연결된 정점의 개수를 리턴하는 메소드
+    public static int query(ArrayList<ArrayList<Integer>> graph, int v1, int v2){
+        int cnt = 1;
+        boolean[] v = new boolean[graph.size()];
+
+        //기본적으로는 BFS탐색을 통하여 정점의 개수를 구할 것이므로 큐를 선언함
+        Queue<Integer> q = new LinkedList<Integer>();
+        
+        //v1에 포함되는 영역만 탐색할 것이므로 v1만 큐에 추가함
+        q.add(v1);
+        
+        //v1, v2모두 방문한 것으로 처리함으로써 v2방향으로는 탐색하지 않도록 함
+        v[v1] = true;
+        v[v2] = true;
+        
+        //아직 탐색할 정점이 있다면 계속 탐색함
+        while(!q.isEmpty()){
+        	//현재 정점을 얻음
+            int c = q.poll();
+            
+            //현재 정점과 연결된 다른 정점들을 탐색함
+            for(int i=0; i<graph.get(c).size(); i++){
+            	//인접한 정점을 얻음
+                int n = graph.get(c).get(i);
+                
+                //아직 인접한 정점을 방문한 적이 없다면
+                if(!v[n]){
+                	//해당 인접한 정점을 방문함
+                    q.add(n);
+                    v[n] = true;
+                    
+                    //포함된 그룹원의 개수를 1증가시킴
+                    cnt++;
+                }
+            }
+        }
+        
+        //그룹에 포함된 정점의 개수를 리턴함
+        return cnt;
+    }
+    
+    public int solution(int n, int[][] wires) {
+        int answer = Integer.MAX_VALUE;
+        
+        //간선 정보를 저장할 2차원 어레이 리스트 선언
+        ArrayList<ArrayList<Integer>> graph = new ArrayList<ArrayList<Integer>>();
+        
+        //어레이 리스트 초기화
+        for(int i=0; i<n; i++){
+            graph.add(new ArrayList<Integer>());
+        }
+        
+        //어레이 리스트에 간선정보를 양방향으로 저장함
+        for(int i=0; i<wires.length; i++){
+            graph.get(wires[i][0]-1).add(wires[i][1]-1);
+            graph.get(wires[i][1]-1).add(wires[i][0]-1);
+        }
+        
+        //간선정보를 순차적으로 탐색함
+        for(int i=0; i<wires.length; i++){
+        	//어떤 간선을 선택하여 그 간선을 제거하고, 그 간선에 포함된 두 정점의 각각의 그룹원의 개수를 구하고
+        	//그 그룹원의 개수의 최소값을 누적하여 구함
+            answer = Math.min(answer,Math.abs(query(graph, wires[i][0]-1,wires[i][1]-1)-query(graph, wires[i][1]-1,wires[i][0]-1)));
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://school.programmers.co.kr/learn/courses/30/lessons/86971)


문제 요구사항 : 

<pre>
해당 문제는 완전탐색을 활용하여 BFS 또는 DFS탐색을 수행할 줄 아는지 묻는 문제다.
</pre>

접근 방법 : 

<pre>
해당 문제에서 송전탑의 개수는 N으로 주어졌고, 전선의 길이는 N-1이라고 명시했다.
게다가 전력망 네트워크가 하나의 트리 형태가 아닌 경우는 주어지지 않는다고 했다.
따라서, 해당 문제에서 주어지는 트리는 "스패닝 트리"다.
즉, 최소한의 간선 개수로만 트리가 구성되어 있으므로 사이클은 존재하지 않는다.

간선 정보를 graph에서 제거하고 BFS 또는 DFS탐색후, 다시 간선 정보를 복구시키는 방법도 존재하긴하나,
편의상 간선정보를 제거하기 보다는, 어떤 간선을 선택하고 해당 간선에 포함되는 두 정점을 "미리 방문 처리"하여
서로 상대방의 영역에 접근하지 못하도록 막으면 쉽게 해결 할 수 있다.

간선의 개수는 많아봐야 99개이므로, 99가지 경우에 대해서 BFS 또는 DFS탐색을 수행하면 된다.
</pre>

풀이 순서 : 

<pre>
1. 주어진 간선 정보를 양방향 그래프에 맵핑함.

2. 주어진 간선 정보를 바탕으로 해당 간선에 포함된 두 정점을 "미리 방문 처리"하고 BFS 또는 DFS탐색을 수행함.

3. 두 영역에 포함된 정점의 개수의 차이의 최소 값을 구함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/207629263-f654d575-4537-449e-867a-cf0eb676aa4c.png)