### PR TITLE
[BOJ] [BFS] [1926] [그림]

### DIFF
--- a/BOJ/BFS/1926/inseonyun/BOJ_1926.cpp
+++ b/BOJ/BFS/1926/inseonyun/BOJ_1926.cpp
@@ -1,0 +1,87 @@
+
+////////////////////////////////////////////////////
+//// BAEKJOON: 1926_±×¸²
+////////////////////////////////////////////////////
+
+#include <iostream>
+#include <queue>
+
+using namespace std;
+
+int N, M;
+int picture[500][500];
+int checked[500][500] = { false, };
+int dx[] = { 0, -1, 0, 1 };
+int dy[] = { -1, 0, 1, 0 };
+int resultCount = 0;
+int resultArea = 0;
+
+void input() {
+	cin >> N >> M;
+
+	for (int row = 0; row < N; row++) {
+		for (int col = 0; col < M; col++) {
+			cin >> picture[row][col];
+		}
+	}
+}
+
+int bfs(int x, int y) {
+	int nowArea = 1;
+
+	checked[x][y] = true;
+
+	queue<pair<int, int>> route;
+
+	route.push({ x, y });
+
+	while (!route.empty()) {
+		int xx = route.front().first;
+		int yy = route.front().second;
+
+		route.pop();
+
+		for (int dir = 0; dir < 4; dir++) {
+			int nx = xx + dx[dir];
+			int ny = yy + dy[dir];
+
+			if (nx >= 0 && ny >= 0 && nx < N && ny < M) {
+				if (picture[nx][ny] == 1 && !checked[nx][ny]) {
+					checked[nx][ny] = true;
+					route.push({ nx, ny });
+					nowArea++;
+				}
+			}
+		}
+	}
+
+	return nowArea;
+}
+
+void solve() {
+	for (int row = 0; row < N; row++) {
+		for (int col = 0; col < M; col++) {
+			if (!checked[row][col] && picture[row][col] == 1) {
+				resultCount++;
+				int nowArea = bfs(row, col);
+				if (nowArea > resultArea)
+					resultArea = nowArea;
+			}
+		}
+	}
+}
+
+void output() {
+	cout << resultCount << "\n" << resultArea;
+}
+
+int main() {
+	ios::sync_with_stdio(false);
+	cin.tie(0);
+
+	input();
+	solve();
+	output();
+
+	return 0;
+}


### PR DESCRIPTION
Source URL : [BOJ : 1926_그림](https://www.acmicpc.net/problem/1926)


문제 요구사항 : 
+ 어떤 큰 도화지에 그림이 그려져 있을 때, 그 그림의 개수와, 그 그림 중 넓이가 가장 넓은 것의 넓이를 출력하여라. 
+ 단, 그림이라는 것은 1로 연결된 것을 한 그림이라고 정의하자. 
+ 가로나 세로로 연결된 것은 연결이 된 것이고 대각선으로 연결이 된 것은 떨어진 그림이다. 
+ 그림의 넓이란 그림에 포함된 1의 개수이다.
+ 첫째 줄에 도화지의 세로 크기 n(1 ≤ n ≤ 500)과 가로 크기 m(1 ≤ m ≤ 500)이 차례로 주어진다. 
+ 두 번째 줄부터 n+1 줄 까지 그림의 정보가 주어진다. (단 그림의 정보는 0과 1이 공백을 두고 주어지며, 0은 색칠이 안된 부분, 1은 색칠이 된 부분을 의미한다)
+ 첫째 줄에는 그림의 개수, 둘째 줄에는 그 중 가장 넓은 그림의 넓이를 출력하여라. 
+ 단, 그림이 하나도 없는 경우에는 가장 넓은 그림의 넓이는 0이다.


접근 방법 :  
+ picture 배열과 방문 배열을 탐색하며, 해당 배열의 값이 1이고, 방문하지 않았을 경우에 해당 좌표를 기준으로 bfs 탐색을 한다. 이때, bfs 탐색 전 값을 count 해서 그림의 개수를 세며, bfs 안에서도 count를 해 해당 그림 넓이를 구한다.


풀이 순서 :
1. N과 M을 입력 받아 해당 크기만큼 picture 배열에 맵 정보를 입력 받는다
2. N과 M의 크기만큼 for문을 반복하여 picture의 인덱스 값이 1이고, 방문하지 않았다면, resultCount를 += 1을 해 그림의 개수를 세고, BFS 탐색을 진행해서 나오는 값을 resultArea 값과 비교해 클 경우에 값을 갱신한다.
3. BFS에서는 매개변수로 받은 좌표를 시작좌표로 두고, 탐색을 진행하며 area의 넓이를 계산하고, 탐색 종료 시 해당 값을 반환한다.
4. 이와 같은 작업 반복
5. resultCount와 resultArea 값 출력


문제 풀이 결과 : 

![image](https://user-images.githubusercontent.com/84364741/210072817-ebe1eb8a-2edb-41a4-8894-a66ffe7730d4.png)
