### PR TITLE
[BOJ] [BFS] [2001] [보석 줍기]

### DIFF
--- a/BOJ/BFS/2001/Blanc_et_Noir/Main.java
+++ b/BOJ/BFS/2001/Blanc_et_Noir/Main.java
@@ -1,0 +1,147 @@
+//https://www.acmicpc.net/problem/2001
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Queue;
+
+//현재 어떤 섬에 있는지, 어떤 섬들의 보석을 주웠는지, 총 몇개의 보석을 주웠는지
+//그러한 정보를 저장하는 노드 클래스 선언
+class Node{
+	//v : 현재 위치한 섬의 번호
+	//k : 현재까지 어떤 섬들의 보석을 주웠는지 비트마스킹의 형태로 저장하는 변수
+	//    예를들어 k = 6이라면 이진수로 110이며, 이는 2, 3번째 섬의 보석은 주웠으나, 1번째 섬의 보석은 아직 줍지 못한 것임
+	//c : 여태까지 몇개의 보석을 주웠는지 저장할 변수
+	int v, k, c;
+	
+	Node(int v, int k, int c){
+		this.v = v;
+		this.k = k;
+		this.c = c;
+	}
+}
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	
+	//보석이 있는 섬의 번호를 key로 사용하여 해당 섬을 Node클래스의 k에 맵핑하기 위한 인덱스를 저장하는 해쉬맵
+	static HashMap<Integer, Integer> index = new HashMap<Integer,Integer>();
+	
+	//간선 정보를 저장하는 2차원 어레이리스트
+	static ArrayList<ArrayList<Node>> graph = new ArrayList<ArrayList<Node>>();
+	
+	//N, M, K는 각각 섬의 개수, 간선의 개수, 보석이 있는 섬의 개수를 의미함
+	static int N, M, K;
+	
+	//특정 island의 보석을 주웠을때의 상태값을 갱신하여 리턴하는 메소드
+	public static int getJewel(HashMap<Integer, Integer> index, int k, int island) {
+		return k | (1<<index.get(island));
+	}
+	
+	//특정 island에의 보석을 이미 주웠는지 아닌지 그 여부를 리턴하는 메소드
+	public static boolean hasJewel(HashMap<Integer, Integer> index, int k, int island) {
+		return (k & (1<<index.get(island))) > 0;
+	}
+	
+	public static int BFS() {
+		int max = 0;
+		
+		//방문배열은 2차원으로 구성됨
+		//v[ n ][ k ]가 의미하는 바는, 번호가 n+1인 섬에 k라는 형태로 보석 섬들의 보석을 주웠을때 방문한 적이 있는지 없는지를 의미함.
+		boolean[][] v = new boolean[N][1<<K];
+		
+		//BFS 탐색을 위한 우선순위 큐 선언
+		Queue<Node> q = new LinkedList<Node>();
+		
+		//1번 섬에, 0개의 보석을 주운 상태로 시작할 수 있도록 큐에 추가후 방문처리함
+		q.add(new Node(0,0,0));
+		v[0][0] = true;
+		
+		while(!q.isEmpty()) {
+			Node cur = q.poll();
+			
+			//만약 1번 섬으로 되돌아 왔다면
+			if(cur.v==0) {
+				//여태까지 주운 보석의 수를 최대값과 비교하여 갱신함
+				max = Math.max(max, cur.c);
+			}
+			
+			//현재 위치한 섬과 인접한 다른 섬들과의 길을 확인함
+			for(int i=0; i<graph.get(cur.v).size(); i++) {
+				//현재 위치한 섬과 이어지는 다른 섬과의 길을 얻음
+				Node next = graph.get(cur.v).get(i);
+
+				//만약 인접한 섬이 보석이 있는 섬이면서, 아직 그 섬의 보석을 줍지 않았을때
+				if(doesIslandHaveJewel(next.v)&&!hasJewel(index,cur.k,next.v)) {
+					//해당 섬의 보석을 주웠다고 가정하고 상태를 업데이트함
+					int newK = getJewel(index, cur.k, next.v);
+					
+					//만약 지금 가지고있는 보석의 개수가 제한 개수 이하이면서
+					//아직 newK라는 형태로 보석을 주워서 도달해본적이 없는 경우에
+					if(cur.c<=next.c&&!v[next.v][newK]) {
+						//주운 보석의 수를 1증가시키고, 주운 보석의 상태를 업데이트한 상태로 큐에 추가하고 방문처리함
+						q.add(new Node(next.v, newK, cur.c+1));
+						v[next.v][newK] = true;
+					}
+				}
+
+				//인접한 섬의 보석 보유 여부와 상관없이 현재 가진 보석의 개수가 제한을 넘지 않고
+				//현재 가진 보석들의 상태로 인접한 섬에 도달해복적이 없다면
+				if(cur.c<=next.c&&!v[next.v][cur.k]) {
+					//인접한 섬에 방문한 것으로 처리함
+					q.add(new Node(next.v, cur.k, cur.c));
+					v[next.v][cur.k] = true;
+				}
+			}
+		}
+		
+		//주운 보석의 최대값을 리턴함
+		return max;
+	}
+	
+	//어떤 섬이 보석을 가지고 있는지 아닌지 판단하는 메소드
+	public static boolean doesIslandHaveJewel(int island) {
+		return index.containsKey(island);
+	}
+	
+	public static void main(String[] args) throws Exception {
+		String[] temp = br.readLine().split(" ");
+		
+		N = Integer.parseInt(temp[0]);
+		M = Integer.parseInt(temp[1]);
+		K = Integer.parseInt(temp[2]);
+
+		//간선 정보를 입력받을 2차원 어레이리스트 초기화
+		for(int i=0; i<N; i++) {
+			graph.add(new ArrayList<Node>());
+		}
+		
+		//보석을 가진 섬들을 차례대로 인덱스를 부여하여 해시맵에 저장함
+		for(int i=0; i<K; i++) {
+			index.put(Integer.parseInt(br.readLine())-1, i);
+		}
+		
+		for(int i=0; i<M; i++) {
+			temp = br.readLine().split(" ");
+			//편의를 위해 섬의 번호가 0부터 시작하도록 함
+			int A = Integer.parseInt(temp[0])-1;
+			int B = Integer.parseInt(temp[1])-1;
+			int C = Integer.parseInt(temp[2]);
+			
+			//양방향 간선이 될 수 있도록 A->B, B->A 두 간선을 추가함
+			graph.get(A).add(new Node(B,0,C));
+			graph.get(B).add(new Node(A,0,C));
+		}
+		
+		bw.write(BFS()+"\n");
+		
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/2001)


문제 요구사항 : 

<pre>
해당 문제는 BFS 탐색 알고리즘을 구현할 줄 아는지, 
비트마스킹을 활용하여 방문배열을 구성할 줄 아는지 묻는 문제다.
</pre>

접근 방법 : 

<pre>
BFS 알고리즘은 보통 최소 또는 최단 값을 구하는데 특화되어있으나, 해당 문제는 최대 값을 구해야 한다.

해당 문제를 해결하기 위해서는 3가지 요소를 잘 파악해야 한다.

첫 번째로, 간선 정보에 주어지는 C값과, 현재 상태를 비교하여 건널 수 있을지, 없을 지를 판단해야 한다.

두 번째로, 건널 수 있다 하더라도 해당 위치에 도달하는데 이미 "완전히 동일한 종류의 보석 집합"을 가지고
방문한 적이 있다면, 굳이 다시 방문할 필요가 없다. (이를 해결하지 못하면 메모리  초과가 발생한다.)

세 번째로, 두 번째 사안에서 "완전히 동일한 종류의 보석 집합"을 가지고 해당 위치에 방문한 적이 있는지 없는지
판단해야 한다고 정의했고, 이를 위해서 방문 배열에는 비트 마스킹 기법이 적용되어야 한다는 것이다.

만약 1, 3, 6번째 섬의 보석을 주웠고, 2, 4, 5번째 섬의 보석은 줍지 않았다면
2진수로 100101(뒤에서부터 1, 2, 3, ... 6번째 섬의 보석을 얻었는지 여부를 1 또는 0으로 표시), 10진수로는 37로 표현할 수 있다.

보석을 가진 섬의 개수는 최대 14개이므로, 1<<14 = 16384개의 조합이 가능하다.
따라서 방문배열은 boolean[ ][ ] v = new boolean[ N ][ 16384 ] 로 나타낼 수 있다.

BFS탐색을 수행할 때에는 아래와 같은 조건으로 탐색한다.

1. 인접한 섬이 보석을 가지고 있고, 내가 해당 섬의 보석을 아직 줍지 못했으며, 
   현재 가진 보석의 개수가 제한 개수 이하이며, 해당 섬의 보석을 주웠을 때 그 때의 주운 보석들의 상태로
   해당 섬에 방문한 적이 없을 때

2. 인접한 섬이 보석을 가지고 있든 없든 간에 현재 가진 보석의 개수가 제한 개수 이하이며, 
   여태까지 주운 보석들의 상태로 해당 섬에 방문한 적이 없을 때

2 가지 경우를 고려하여 방문하면 된다.
</pre>

풀이 순서 : 

<pre>
1. 간선 정보 및 보석을 가진 섬의 정보를 입력 받음.

2. 1번 섬에서 BFS탐색을 시작함.

3. 접근 방법에서 설명한 2가지 경우를 고려하여 인접한 섬에 방문할 것인지 말 것인지 결정함.

4. 다시 1번 섬으로 돌아왔을 때 주운 보석의 개수가 최대 값보다 크면 그것을 최대 값으로 갱신함.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/212465096-1d6765b7-da92-419a-b8cc-eec8dd4df23b.png)