### PR TITLE
[BOJ] [Binary-Search] [16564] [히오스 프로게이머]

### DIFF
--- a/BOJ/Binary-Search/16564/Blanc_et_Noir/Main.java
+++ b/BOJ/Binary-Search/16564/Blanc_et_Noir/Main.java
@@ -1,0 +1,76 @@
+//https://www.acmicpc.net/problem/16564
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+	public static void main(String[] args) throws Exception {
+		String[] temp = br.readLine().split(" ");
+		long N = Long.parseLong(temp[0]);
+		long K = Long.parseLong(temp[1]);
+		
+		//최소로 올리고자 하는 팀 레벨
+		long min = 1;
+		
+		//최대로 올리고자 하는 팀 레벨
+		long max = 2000000000;
+		
+		long[] arr = new long[(int) N];
+		
+		//현재 캐릭터들의 레벨을 입력받음
+		for(int i=0; i<N; i++) {
+			arr[i] = Long.parseLong(br.readLine());
+		}
+		
+		//팀 레벨을 최소 몇까지 올릴 수 있는지 저장할 변수
+		long answer = 0;
+		
+		while(min<=max) {
+			//최소와 최대로 올리고자 하는 팀 레벨의 중간값을 구함
+			long mid = (min+max)/2L;
+			
+			//중간값만큼 팀 레벨을 올리기위해서 캐릭터의 레벨을 얼마나 올렸는지 저장할 변수
+			long sum = 0;
+			
+			//중간값만큼 팀 레벨을 올리려고 할 때 K이하로 캐릭터 레벨을 올릴 수 있는지 확인할 변수
+			boolean flag = true;
+			
+			for(int i=0; i<arr.length; i++) {
+				//만약 해당 캐릭터의 레벨이 기준에 못 미친다면
+				if(arr[i]<mid) {
+					//부족한 만큼을 레벨업시킴
+					sum += (mid-arr[i]);
+				}
+				
+				//만약 K를 초과하여 캐릭터를 레벨업 시켰다면
+				if(sum>K) {
+					//불가능한 것임
+					flag=false;
+					break;
+				}
+			}
+			
+			//팀 레벨을 mid까지 올리는 것이 가능하다면, 아직 여유가 있는 것임
+			if(flag) {
+				//그 기준이 될 팀 레벨을 증가시키고자 min값을 mid+1로 갱신함
+				min = mid+1;
+				//mid가 아직까진 최대로 올릴 수 있는 팀 레벨임
+				answer = mid;
+			//팀 레벨을 mid까지 올리는 것이 불가능하다면 여유가 없는 것임
+			}else {
+				//그 기준이 될 팀 레벨을 낮추고자 max값을 mid-1로 갱신함
+				max = mid-1;
+			}
+		}
+		
+		bw.write(answer+"\n");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/16564)


문제 요구사항 : 

<pre>
해당 문제는 파라메트릭 서치 알고리즘을 활용할 줄 아는지를 묻는 문제다.
</pre>

접근 방법 : 

<pre>
해당 문제의 조건에 따르면 최대 팀의 레벨은 자신이 보유한 캐릭터들의 레벨의 최소 값이 된다.
즉, 팀의 레벨을 최대로 끌어올리기 위해서는,
자신이 보유한 캐릭터들 중에서 레벨이 가장 작은 캐릭터를 우선적으로 키울 필요가 있다.

캐릭터의 레벨을 총 K만큼 올릴 수 있는데, K의 크기는 최대 10억이므로
우선순위 큐를 활용한 알고리즘으로는 문제를 해결할 수 없다.

즉, 레벨이 가장 작은 캐릭터를 우선순위 큐에서 꺼내고, 레벨을 1증가시키고, 다시 큐에 추가하는 것은
O(NlogN)의 시간복잡도를 갖는데, 이때 최악의 경우 10억 * log 100만 만큼의 연산이 필요하다.

이 문제는 회귀문제를 결정트리 문제로 변형하여 해결하는 파라메트릭 서치(매개변수 탐색) 알고리즘으로 해결 가능하다.
시간복잡도는 동일하게 O(NlogN)이지만, 100만 * log 10억이므로 쉽게 문제를 해결할 수 있다.

목표하고자 하는 팀 레벨을 mid라고 정했을때, 이 mid보다 작은 영웅들을 모두 mid만큼 레벨업을 시킨다.
만약 그렇게 레벨업을 시킨 정도가 K보다 큰지, 작은지, 같은지에 따라 적절히 mid값을 절반 증가시키거나, 감소시킨다.

만약 레벨업을 시킨 횟수가 K보다 크다면, 최소 레벨이 더 낮아질 수도 있으므로 mid값을 절반 감소시킨다.
만약 레벨업을 시킨 횟수가 K보다 작다면, 최소 레벨이 더 높아질 수도 있으므로 mid값을 절반 증가시킨다.
만약 레벨업을 시킨 횟수가 K라면, 최소 레벨이 더 높아질 수도 있으므로 mid값을 절반 증가시킨다.

레벨업을 시킨 횟수가 K보다 작거나, 같을때만 mid값을 answer로 기록해둔다.
</pre>

풀이 순서 : 

<pre>
1. 캐릭터들의 레벨, 올릴 수 있는 레벨의 총합을 입력 받는다.

2. 파라메트릭 서치를 통해 아래와 같이 분기하여 적절한 mid값을 찾는다.

3. 레벨업을 시킨 횟수가 K보다 크다면, mid 값을 감소시킨다.

4. 레벨업을 시킨 횟수가 K보다 작다면, mid 값을 증가시킨다. 그 후 mid를 기록한다.

5. 레벨업을 시킨 횟수가 K와 같다면, mid 값을 증가시킨다. 그 후 mid를 기록한다.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/212601340-05fb7da1-167b-43ac-9148-c860ef9f0790.png)