### PR TITLE
[PGS] [Prefix-Sum] [파괴되지 않은 건물]

### DIFF
--- a/PGS/Prefix-Sum/파괴되지-않은-건물/Blanc_et_Noir/Solution.java
+++ b/PGS/Prefix-Sum/파괴되지-않은-건물/Blanc_et_Noir/Solution.java
@@ -1,0 +1,61 @@
+//https://school.programmers.co.kr/learn/courses/30/lessons/92344
+
+class Solution {
+	//누적합할 가중치를 누적합 배열에 누적시키는 메소드
+    public void add(int[][] temp,int r1, int c1, int r2, int c2, int v){
+        temp[r1][c1] += v;
+        temp[r1][c2+1] -= v;
+        temp[r2+1][c1] -= v;
+        temp[r2+1][c2+1] += v;
+    }
+    
+    //누적합을 가로로 수행하는 메소드
+    public void processHorizontally(int[][] temp){
+        for(int i=0; i<temp.length; i++){
+            for(int j=1; j<temp[0].length; j++){
+                temp[i][j] += temp[i][j-1];
+            }
+        }
+    }
+    
+    //누적합을 세로로 수행하는 메소드
+    public void processVertically(int[][] temp){
+        for(int j=0; j<temp[0].length; j++){
+            for(int i=1; i<temp.length; i++){
+                temp[i][j] += temp[i-1][j];
+            }
+        }
+    }
+    
+    public int solution(int[][] board, int[][] skill) {
+        int answer = 0;
+        
+        //가중치를 누적해둘 누적 배열 선언
+        int[][] temp = new int[board.length+1][board[0].length+1];
+        
+        //스킬을 차례대로 탐색함
+        for(int i=0; i<skill.length; i++){
+        	//가중치v가 회복스킬이라면 +, 공격스킬이라면 -값을 갖도록 함
+            int v = (skill[i][0]==1?-skill[i][5]:skill[i][5]);
+            
+            //가중치를 누적함
+            add(temp,skill[i][1],skill[i][2],skill[i][3],skill[i][4],v);
+        }
+        
+        //2차원 배열의 누적합을 구함
+        processHorizontally(temp);
+        processVertically(temp);
+        
+        //누적합을 구한 누적합 배열과 원본 배열을 합함
+        for(int i=0; i<board.length; i++){
+            for(int j=0; j<board[0].length; j++){
+            	//누적된 결과를 실제 원본 배열에 반영했을때 0보다 큰 값을 갖는다면 파괴되지 않은 건물임
+                if(board[i][j]+temp[i][j]>0){
+                    answer++;
+                }
+            }
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://school.programmers.co.kr/learn/courses/30/lessons/92344)


문제 요구사항 : 

<pre>
해당 문제는 2차원 배열의 누적합을 구하는 방법을 알고 있는지,
이를 활용하여 문제를 해결할 줄 아는지 묻는 문제다.
</pre>

접근 방법 : 

<pre>
1차원 배열의 누적합을 구하는 방법은 간단하다.
아래와 같은 배열이 존재한다고 가정하자.

인덱스 :      [ 0 ][ 1 ][ 2 ][ 3 ][ 4 ][ 5 ][ 6 ][ 7 ][ 8 ][ 9 ]
누적합 배열 : [ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ]

이때 0 ~ 8번 인덱스에 N만큼을 누적하여 더하고 싶다면 아래와 같이 인덱스 0과, 인덱스 8+1에 각각 N, -N을 더한다.
인덱스 :      [ 0 ][ 1 ][ 2 ][ 3 ][ 4 ][ 5 ][ 6 ][ 7 ][ 8 ][ 9 ]
누적합 배열 : [ N ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][-N ]

그 후에 arr[ i + 1 ] = arr[ i  + 1 ] + arr[ i ]와 같은 점화식을 통해 누적합을 구한다.
인덱스 :      [ 0 ][ 1 ][ 2 ][ 3 ][ 4 ][ 5 ][ 6 ][ 7 ][ 8 ][ 9 ]
누적합 배열 : [ N ][ N ][ N ][ N ][ N ][ N ][ N ][ N ][ N ][ 0 ]

2차원 배열의 누적합은 기본적인 원리는 1차원 배열의 누적합과 동일하다.
다만, 2차원 배열의 누적합은 아래와 같이 진행된다.

왼쪽 위의 모서리의 좌표가 (y1, x1) , 오른쪽 아래 모서리의 좌표가 (y2, x2)인 사각형 영역에 대하여 N만큼을 누적하여 더하고자 한다면, (y1, x1)과 (y2+1, x2+1) 좌표에는 N을 누적하여 더하고, (y1, x2+1)와 (y2+1, x1) 좌표에는 -N을 누적하여 더한다.

예를 들어 (3,2), (7, 8)을 모서리로 하는 사각형 영역에 N을 누적하여 더하고자 한다면 아래와 같이 N과 -N을 누적하여 더한다.

     [ 0 ][ 1 ][ 2 ][ 3 ][ 4 ][ 5 ][ 6 ][ 7 ][ 8 ][ 9 ]
[ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ]
[ 1 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ]
[ 2 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ]
[ 3 ][ 0 ][ 0 ][ N ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][-N ]
[ 4 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ]
[ 5 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ]
[ 6 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ]
[ 7 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ]
[ 8 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ N ]
[ 9 ][ 0 ][ 0 ][-N ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ]

그 후에 가로 및 세로 방향으로 1차원 배열처럼 누적합을 구하면 된다.

     [ 0 ][ 1 ][ 2 ][ 3 ][ 4 ][ 5 ][ 6 ][ 7 ][ 8 ][ 9 ]
[ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ]
[ 1 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ]
[ 2 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ]
[ 3 ][ 0 ][ 0 ][ N ][ N ][ N ][ N ][ N ][ N ][ N ][ 0 ]
[ 4 ][ 0 ][ 0 ][ N ][ N ][ N ][ N ][ N ][ N ][ N ][ 0 ]
[ 5 ][ 0 ][ 0 ][ N ][ N ][ N ][ N ][ N ][ N ][ N ][ 0 ]
[ 6 ][ 0 ][ 0 ][ N ][ N ][ N ][ N ][ N ][ N ][ N ][ 0 ]
[ 7 ][ 0 ][ 0 ][ N ][ N ][ N ][ N ][ N ][ N ][ N ][ 0 ]
[ 8 ][ 0 ][ 0 ][ N ][ N ][ N ][ N ][ N ][ N ][ N ][ 0 ]
[ 9 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ][ 0 ]

2차원 배열의 크기는 최대 1000 x 1000이며, 스킬의 개수는 최대 100개다.
스킬 100개에 대하여 초기에 N과 -N을 누적하는 것은 시간복잡도가 O(1)이므로 간단하게 처리할 수 있다.

2차원 배열의 누적합을 구하는 것은 O(N^2)의 시간복잡도를 가지지만, 2차원 배열의 크기가 1000 x 1000이므로
누적합을 구하는데에 그리 오랜시간이 걸리지 않는다.

공격 또는 회복 스킬을 임시 2차원 누적합 배열에 누적하여 그 값을 구하고
그 임시 2차원 배열과 초기에 입력으로 주어진 2차원 배열의 값을 합하여 0을 초과하는 경우에 대해서
카운팅을 해주면 그것이 곧 파괴되지 않은 건물의 개수가 된다.
</pre>

풀이 순서 : 

<pre>
1. 모든 스킬에 대하여 2차원 배열의 누적합을 구한다.

2. 누적합이 기록된 2차원 배열과 초기 배열을 합하여 0보다 큰 값이 몇 개나 존재하는지 카운팅한다.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/214489075-4c11343d-cad9-411e-bce1-0b47fb4f55d4.png)