### PR TITLE
[BOJ] [BFS] [7562] [나이트의 이동]

### DIFF
--- a/BOJ/BFS/7562/Blanc_et_Noir/Main.java
+++ b/BOJ/BFS/7562/Blanc_et_Noir/Main.java
@@ -1,0 +1,98 @@
+//https://www.acmicpc.net/problem/7562
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+
+//y, x좌표 및 이동 횟수를 저장할 노드 클래스
+class Node{
+	int y, x, c;
+	Node(int y, int x, int c){
+		this.y=y;
+		this.x=x;
+		this.c=c;
+	}
+}
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	
+	//s정점에서 e정점으로 이동하기 위한 최소 비용을 리턴하는 메소드
+	public static int BFS(int[][] v, Node s, Node e) {
+		//나이트의 이동 방법을 표현하기 위한 배열
+		int[][] dist = new int[][] {{-2,-1},{-2,1},{-1,2},{1,2},{2,1},{2,-1},{1,-2},{-1,-2}};
+		
+		//방문 배열을 모두 MAX_VALUE로 초기화
+		for(int i=0; i<v.length; i++) {
+			Arrays.fill(v[i], Integer.MAX_VALUE);
+		}
+		
+		Queue<Node> q = new LinkedList<Node>();
+		q.add(s);
+		
+		//시작 정점은 0의 비용으로 도착했음을 표시
+		v[s.y][s.x] = 0;
+		
+		//이동하는데 필요한 최소 비용
+		int cnt = 0;
+		
+		while(!q.isEmpty()) {
+			Node n = q.poll();
+			
+			//도착 지점에 도달했다면
+			if(n.y==e.y&&n.x==e.x) {
+				//그것이 최소 비용임이 보장됨
+				cnt = n.c;
+				break;
+			}
+			
+			//현재 위치에서 8방향 모두 탐색함
+			for(int i=0; i<dist.length; i++) {
+				int y = n.y + dist[i][0];
+				int x = n.x + dist[i][1];
+				
+				//만약 해당 위치에 방문한 적 없고, 맵을 벗어나지도 않으면
+				if(y>=0&&y<v.length&&x>=0&&x<v[0].length&&v[y][x]>n.c+1) {
+					//해당 지점에 방문함
+					q.add(new Node(y,x,n.c+1));
+					v[y][x]=n.c+1;
+				}
+			}
+			
+		}
+		
+		//이동하는데 필요한 최소 비용을 리턴함
+		return cnt;
+	}
+	
+	public static void main(String[] args) throws Exception {
+		int T = Integer.parseInt(br.readLine());
+		
+		//각 테스트케이스에 대해
+		for(int i=0; i<T; i++) {
+			//맵의 크기를 입력 받음
+			int N = Integer.parseInt(br.readLine());
+			
+			//시작 및 종료 정점 위치를 입력 받음
+			String[] temp = br.readLine().split(" ");
+			int sy = Integer.parseInt(temp[0]);
+			int sx = Integer.parseInt(temp[1]);
+			
+			temp = br.readLine().split(" ");
+			int ey = Integer.parseInt(temp[0]);
+			int ex = Integer.parseInt(temp[1]);
+			
+			//나이트가 종료지점으로 이동하는데 필요한 최소 비용을 출력함
+			bw.write(BFS(new int[N][N],new Node(sy,sx,0),new Node(ey,ex,0))+"\n");
+		}
+
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/7562)


문제 요구사항 : 

<pre>
해당 문제는 BFS 알고리즘을 구현할 줄 아는지 묻는 문제다.
</pre>

접근 방법 : 

<pre>
나이트의 이동 방법은 1칸을 상, 하, 좌, 우 등 네 방향중 한 방향으로 이동하고,
이어서 진행방향을 기준으로 대각선으로 1칸을 더 이동하는 것이다.

이를 BFS탐색을 용이하게 하기 위한 벡터 배열로 표현하려면 (-1,2), (-2, -1)과 같이 표현할 수 있다.
이러한 벡터 배열을 사용해서 현재 위치를 기준으로, 다음 위치를 쉽게 계산할 수 있다.
</pre>

풀이 순서 : 

<pre>
1. 맵의 크기를 입력 받음.

2. 시작 및 종료 위치를 입력 받음.

3. 시작 위치에서부터 BFS탐색을 수행하며, 종료위치에 도달할 때 까지 탐색을 진행한다.

5. 종료위치에 도달시 그때의 이동 횟수를 출력한다.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/218265885-0ea8aaef-f9dd-4806-a3e4-f77f75eb9634.png)