### PR TITLE
[BOJ] [BFS] [2644] [촌수계산]

### DIFF
--- a/BOJ/BFS/2644/Blanc_et_Noir/Main.java
+++ b/BOJ/BFS/2644/Blanc_et_Noir/Main.java
@@ -1,0 +1,98 @@
+//https://www.acmicpc.net/problem/2644
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Queue;
+
+//정점 번호와 촌수를 저장한 노드 클래스 선언
+class Node{
+	int v, c;
+	Node(int v, int c){
+		this.v=v;
+		this.c=c;
+	}
+}
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	
+	public static void main(String[] args) throws Exception {
+		//전체 사람 수를 입력 받음
+		int N = Integer.parseInt(br.readLine());
+		String[] temp = br.readLine().split(" ");
+		
+		//탐색을 시작할 정점과 종료할 정점을 입력 받음
+		int S = Integer.parseInt(temp[0])-1;
+		int E = Integer.parseInt(temp[1])-1;
+		
+		//간선의 개수를 입력 받음
+		int M = Integer.parseInt(br.readLine());
+		
+		//간선 정보를 저장할 2차원 어레이리스트 선언
+		ArrayList<ArrayList<Node>> g = new ArrayList<ArrayList<Node>>();
+		
+		//2차원 어레이리스트 초기화
+		for(int i=0; i<N; i++) {
+			g.add(new ArrayList<Node>());
+		}
+		
+		//간선정보를 입력받음
+		for(int i=0; i<M; i++) {
+			temp = br.readLine().split(" ");
+			
+			int A = Integer.parseInt(temp[0])-1;
+			int B = Integer.parseInt(temp[1])-1;
+			
+			//간선 정보를 양방향으로 입력받고 저장함
+			g.get(A).add(new Node(B,1));
+			g.get(B).add(new Node(A,1));
+		}
+		
+		//BFS탐색에 사용할 큐를 선언
+		Queue<Node> q = new LinkedList<Node>();
+		
+		//정점 S부터 탐색할 수 있도록 큐에 추가함
+		q.add(new Node(S,0));
+		
+		//정점 S부터 탐색을 시작하도록 방문처리함
+		boolean[] v = new boolean[N];
+		v[S] = true;
+		
+		//결과를 저장할 변수
+		int answer = -1;
+		
+		while(!q.isEmpty()) {
+			Node n = q.poll();
+			
+			//만약 종료 정점에 도달했다면
+			if(n.v == E) {
+				//그때까지의 촌수를 결과 변수에 저장하고 반복을 종료함
+				answer = n.c;
+				break;
+			}
+			
+			//현재 탐색의 기준이 되는 자신과 인접한 노드들을 탐색함
+			for(int i=0; i<g.get(n.v).size(); i++) {
+				//인접한 노드 정보를 얻음
+				Node node = g.get(n.v).get(i);
+				
+				//인접한 정점에 방문한 적이 없다면
+				if(!v[node.v]) {
+					//방문처리하고, BFS탐색을 이어나가도록 큐에 추가함
+					v[node.v]=true;
+					q.add(new Node(node.v,n.c+node.c));
+				}
+			}
+		}
+		
+		bw.write(answer+"\n");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/2644)


문제 요구사항 : 

<pre>
해당 문제는 BFS탐색의 기본 원리를 알고 있는지 묻는 문제다.
</pre>

접근 방법 : 

<pre>
촌수를 계산하는 것은, 보통 방향이 정해져 있지 않다.
가령 할아버지와 나의 촌수를 계산하는 것은, 할아버지부터, 아버지, 나까지 탐색하며 촌수를 계산할 수도 있지만,
나, 아버지, 할아버지 순으로 탐색하여 촌수를 계산할 수도 있다.

따라서, 간선 정보는 단방향이 아니라 양방향으로 저장해야 하며,
문제의 조건에 따르면 자신의 부모는 단 1명만 존재한다고 명시되어 있으므로,
방문 배열은 int와 같은 숫자 타입이 아닌, boolean 타입으로도 구현할 수 있다.

부모가 여럿이었을 경우, 특정 정점까지 탐색하기 위해 계산된
촌수의 최소 값, 최대 값 등을 구하는 문제였다면 int로 구성해야 한다.
</pre>

풀이 순서 : 

<pre>
1. 간선정보를 양방향으로 취급하여 입력 받는다.

2. 정점 S부터, E까지 BFS탐색을 수행하며, 촌수를 누적하여 카운트한다.

3. 정점 E에 도달했을 경우 해당 촌수를 출력한다.

4. 정점 E에 도달한 적이 없다면 -1을 출력한다.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/218294685-f5f897ab-c556-48bd-9989-c58f620a6707.png)