### PR TITLE
[BOJ] [BFS] [14948] [군대탈출하기]

### DIFF
--- a/BOJ/BFS/14948/Blanc_et_Noir/Main.java
+++ b/BOJ/BFS/14948/Blanc_et_Noir/Main.java
@@ -1,0 +1,163 @@
+//https://www.acmicpc.net/problem/14948
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.PriorityQueue;
+
+//y, x좌표 및 여태까지 필요한 최대 레벨, 남은 특수장비 사용가능 횟수를 저장할 노드 클래스
+class Node implements Comparable<Node>{
+	int y, x, v, c;
+	Node(int y, int x, int v, int c){
+		this.y=y;
+		this.x=x;
+		this.c=c;
+		this.v=v;
+	}
+	
+	//최대 레벨이 적은 노드가 먼저 반환되며
+	//둘다 레벨이 동일하면, 특수장비 사용가능 횟수가 더 적은 노드가 먼저 반환되도록 함
+	@Override
+	public int compareTo(Node n) {
+		if(this.v<n.v) {
+			return -1;
+		}else if(this.v>n.v) {
+			return 1;
+		}else if(this.c>n.c){
+			return -1;
+		}else if(this.c<n.c) {
+			return 1;
+		}
+		
+		return 0;
+	}
+}
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	
+	//군대를 탈출했는지, 아닌지를 검증하는 메소드
+	public static boolean isFinished(int[][] arr, Node n) {
+		if(n.y==arr.length-1&&n.x==arr[0].length-1) {
+			return true;
+		}
+		
+		return false;
+	}
+	
+	//좌표가 맵을 벗어나는지 아닌지를 리턴하는 메소드
+	public static boolean isInRange(int[][] arr, int y, int x) {
+		if(y>=0&&y<arr.length&&x>=0&&x<arr[0].length) {
+			return true;
+		}
+		
+		return false;
+	}
+	
+	//해당 위치에 방문할 수 있는지 없는지를 리턴하는 메소드
+	public static boolean canVisit(int[][][] visit, int y, int x, int v, int c) {
+		if(visit[y][x][c] > v) {
+			return true;
+		}
+		
+		return false;
+	}
+	
+	public static void main(String[] args) throws Exception {
+		String[] temp = br.readLine().split(" ");
+		
+		//맵의 크기를 입력받음
+		int H = Integer.parseInt(temp[0]);
+		int W = Integer.parseInt(temp[1]);
+		
+		int[][] arr = new int[H][W];
+		
+		//맵 정보를 입력받음
+		for(int i=0; i<H; i++) {
+			temp = br.readLine().split(" ");
+			for(int j=0; j<W; j++) {
+				arr[i][j] = Integer.parseInt(temp[j]);
+			}
+		}
+		
+		//방문배열은 y, x좌표 및 특수장비 사용 횟수를 인덱스로 가짐
+		int[][][] visit = new int[H][W][2];
+		
+		//BFS탐색에 사용할 벡터 배열
+		int[][] dist = new int[][] {{-1,0},{1,0},{0,-1},{0,1}};
+		
+		//우선순위큐를 활용하여 BFS탐색을 수행
+		//최대 레벨이 더 적은 노드가 먼저 반환되며, 동일하다면 특수장비를 아직 사용하지 않은 노드가 먼저 반환됨
+		PriorityQueue<Node> pq = new PriorityQueue<Node>();
+		pq.add(new Node(0,0,arr[0][0],1));
+		
+		//방문배열을 MAX_VALUE로 초기화
+		for(int i=0; i<visit.length; i++) {
+			for(int j=0;j<visit[0].length; j++) {
+				for(int k=0; k<visit[0][0].length; k++) {
+					visit[i][j][k] = Integer.MAX_VALUE;
+				}
+			}
+		}
+		
+		//시작 위치에서의 최대 레벨은 곧 0,0 위치의 레벨
+		visit[0][0][1] = arr[0][0];
+		
+		int answer = 0;
+		
+		while(!pq.isEmpty()) {
+			Node n = pq.poll();
+			
+			//군대를 탈출했다면
+			if(isFinished(arr,n)) {
+				//그때의 최대 레벨이 곧 최소값임을 보장할 수 있으며 반복 종료함
+				answer = n.v;
+				break;
+			}
+			
+			for(int i=0; i<dist.length; i++) {
+				int y = n.y + dist[i][0];
+				int x = n.x + dist[i][1];
+				
+				//맵의 범위를 벗어나지 않는다면
+				if(isInRange(arr,y,x)) {
+					//현재 가진 최대 레벨과 해당 위치에 도달했을때의 레벨중 더 큰 값을 max로 지정
+					int max = Math.max(n.v,arr[y][x]);
+					
+					//만약 max 레벨로 특수장비를 사용하지 않고 해당 위치로 이동해도
+					//기존에 기록된 레벨보다 max 레벨이 더 작아서 방문할 수 있다면
+					if(canVisit(visit,y,x,max,n.c)) {
+						//해당 위치를 방문처리함
+						pq.add(new Node(y,x,max,n.c));
+						visit[y][x][n.c] = max;
+					}
+				}
+				
+				//특수장비를 사용했을 때의 좌표
+				int dy = n.y + dist[i][0]*2;
+				int dx = n.x + dist[i][1]*2;
+				
+				//만약 특수장비 사용 횟수가 남아있고, 맵을 벗어나지 않는다면
+				if(n.c>0&&isInRange(arr,dy,dx)) {
+					//현재 가진 최대 레벨과 해당 위치에 도달했을때의 레벨중 더 큰 값을 max로 지정
+					int max = Math.max(n.v,arr[dy][dx]);
+					
+					//만약 max 레벨로 특수장비를 사용하고 해당 위치로 이동해도
+					//기존에 기록된 레벨보다 max 레벨이 더 작아서 방문할 수 있다면
+					if(canVisit(visit,dy,dx,max,n.c-1)) {
+						//해당 위치를 방문처리함
+						pq.add(new Node(dy,dx,max,n.c-1));
+						visit[y][x][n.c-1] = max;
+					}
+				}
+			}
+		}
+		
+		bw.write(answer+"\n");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/14948)


문제 요구사항 : 

<pre>
해당 문제는 BFS탐색을 구현할 줄 아는 지, 활용할 줄 아는 지를 묻는 문제다.
또한 적절한 방문 배열 형태를 구성할 줄 알아야 한다.
</pre>

접근 방법 : 

<pre>
이 문제를 해결하려면 최소 2가지 요소를 먼저 고려해야 한다.

첫 번째로는 방문 배열의 형태를 고려해야 한다.
먼저 y, x좌표를 방문배열의 인덱스로 사용해야 하며, 추가적으로 특수장비 사용 횟수를 인덱스로 사용해야한다.
동일한 y, x좌표에 도달했다 하더라도, 특수장비 사용 여부에 따라 다음 이동에 영향을 미칠 수 있기 때문이다.
또한 동일한 특수장비 사용 여부 및 동일한 y, x좌표로 해당 위치에 방문할 때, 재방문을 허용할 수 있어야 한다.

해당 위치에 도달하기 위해서 기존에 H라는 최대 레벨을 가지고 방문했는데,
나중에 그보다 작은 h라는 최대 레벨을 가지고 방문한다면, 재방문 할 수 있어야 최대 레벨의 최소값을 구할 수 있기 때문이다.
따라서 방문 배열의 형태는 int[ y ][ x ][ c ] v = h의 형태여야 하며 y, x는 각각 좌표, c는 특수장비 사용횟수,
h는 해당 위치에 도달하기 위해 접한 레벨들의 최대 값을 의미한다.

두 번째로는 일반 큐가 아닌 우선순위 큐를 사용해야 한다.
어떤 위치에 이동할 때마다 여태까지 접한 레벨들의 최대 값이 갱신될 수 있는데, 이때 레벨이 1씩 증가한다는 보장이 없다.
갑자기 10씩 증가할 수도 있기 때문에, 일반적인 큐를 활용해서 BFS를 수행할 경우, 목적지에 도달했다고 해서
즉시 BFS탐색을 종료하면 그것이 최대 레벨의 최소값이 됨을 보장할 수 없게 된다.

따라서 우선순위 큐를 사용하여 최대 레벨이 가장 작은 노드가 우선적으로 탐색될 수 있도록 해야하며
그러한 노드가 여러 개 존재한다면, 특수 장비 사용 횟수가 더 많이 남아있는 노드를 먼저 탐색해야 한다.
</pre>

풀이 순서 : 

<pre>
1. 맵의 정보를 입력받고, BFS탐색을 위한 우선순위 큐를 선언한다.

2. 시작 위치부터 우선순위 큐를 활용하여 BFS탐색을 수행하며 목적지에 도달하면
   그때 노드에 저장된 최대 레벨을 출력하고 반복을 종료한다.

3. 아니라면 아래와 같이 분기하며 BFS탐색을 진행한다.

4. 특수 장비 사용 횟수가 남아있고, 특수 장비를 사용하여 해당 위치에 도달했을 때의 최대 레벨이 기존에 기록한 최대 레벨보다
   작다면, 특수 장비를 사용하고 해당 위치에 방문한다. 그리고 그때의 최대 레벨을 방문 배열에 기록한다.

5. 특수 장비 잔여 사용 회수와는 상관없이 항상 해당 위치에 도달했을 때의 최대 레벨이 기존에 기록한 최대 레벨보다 작다면
   작다면, 해당 위치에 방문한다. 그리고 그때의 최대 레벨을 방문 배열에 기록한다.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/219060328-6a03d149-44f1-42b4-9932-76f2e865eec3.png)