### PR TITLE
[PGS] [Binary-Search] [시소 짝꿍]

### DIFF
--- a/PGS/BinarySearch/시소-짝꿍/Blanc_et_Noir/Solution.java
+++ b/PGS/BinarySearch/시소-짝꿍/Blanc_et_Noir/Solution.java
@@ -1,0 +1,84 @@
+//https://school.programmers.co.kr/learn/courses/30/lessons/152996
+
+import java.util.*;
+
+class Solution {
+	//인덱스 l부터 배열의 끝까지의 구간에서 가중치를 w만큼을 곱한 값이 v와 동일하거나
+	//그보다 큰 정수가 처음 나타나는 때의 인덱스를 반환하는 메소드	
+    public int lowerbound(int[] arr, int l, int v, int w){
+        int r = arr.length;
+        
+        //l값이 r보다 작을때 반복 수행
+        while(l<r){
+        	//중간 인덱스를 구함
+            int m = (l+r)/2;
+            
+            //만약 중간 인덱스에 해당하는 값을 w만큼 곱했을때의 값이 찾고자하는 v값보다 크거나 같다면
+            if(arr[m]*w>=v){
+            	//lowerbound값 중에서 그보다 더 작은 인덱스가 존재할 수 있으므로 r값을 줄여봄
+                r = m;
+            //만약 중간 인덱스에 해당하는 값을 w만큼 곱했을때의 값이 찾고자하는 v값보다 작다면
+            }else{
+            	//lowerbound값은 인덱스 m보다 우측에 있으므로 l값을 늘려봄
+                l = m + 1;
+            }
+        }
+        
+        //찾지 못했다면 r값은 arr.length와 같으며, 찾았다면 그 인덱스를 반환
+        return r;
+    }
+    
+    //인덱스 l부터 배열의 끝까지의 구간에서 가중치를 w만큼을 곱한 값이
+  	//그보다 큰 정수가 처음 나타나는 때의 인덱스를 반환하는 메소드	
+    public int upperbound(int[] arr, int l, int v, int w){
+        int r = arr.length;
+        
+        //l값이 r보다 작을때 반복 수행
+        while(l<r){
+        	//중간 인덱스를 구함
+            int m = (l+r)/2;
+            
+            //만약 중간 인덱스에 해당하는 값을 w만큼 곱했을때의 값이 찾고자하는 v값보다 크다면
+            if(arr[m]*w>v){
+            	//upperbound값 중에서 그보다 더 작은 인덱스가 존재할 수 있으므로 r값을 줄여봄
+                r = m;
+            //만약 중간 인덱스에 해당하는 값을 w만큼 곱했을때의 값이 찾고자하는 v값보다 작거나 같다면
+            }else{
+            	//upperbound값은 인덱스 m보다 우측에 있으므로 l값을 늘려봄
+                l = m + 1;
+            }
+        }
+        
+        //찾지 못했다면 r값은 arr.length와 같으며, 찾았다면 그 인덱스를 반환
+        return r;
+    }
+    
+    public long solution(int[] weights) {
+        long answer = 0;
+        
+        //2:2, 2:3, 2:4, 3:2, 3:3, 3:4, 4:2, 4:3, 4:4와 같은 비율이 존재할 수 있으나
+        //약분했을때 중복되는 비율을 제거해보면 1:1, 1:2, 2:1, 1:3, 3:1, 1:4, 4:1의 비율로 줄일 수 있음
+        //그러나 몸무게를 오름차순 정렬한다면, 기준이 될 몸무게는 반드시 자신보다 오른쪽에 존재하는 몸무게보다는 작거나 같음이 보장되므로
+        //1:2, 1:3, 1:4 비율은 전혀 고려할 필요가 없음, 따라서 1:1, 2:1, 3:1, 4:1 비율만 고려하면 됨
+        int[][] dist = new int[][]{
+            {1,1},{2,1},{3,2},{4,3}
+        };
+        
+        //몸무게를 오름차순 정렬함
+        Arrays.sort(weights);
+        
+        for(int i=0; i<weights.length-1; i++){
+            for(int j=0; j<dist.length; j++){
+            	//자신의 몸무게에 가중치를 곱함
+                int me = weights[i]*dist[j][0];
+                
+                //자신보다 오른쪽에 있는 수들에 대하여 dist[i][j]만큼의 가중치를 곱했을때
+                //자기 자신과 동일한 값이 몇개나 존재하는지를 확인함
+                answer += upperbound(weights,i+1,me,dist[j][1]) - lowerbound(weights,i+1,me,dist[j][1]);
+                
+            }
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://school.programmers.co.kr/learn/courses/30/lessons/152996)


문제 요구사항 : 

<pre>
해당 문제는 이진 탐색 알고리즘을 아는지, 이를 활용하여 문제를 해결할 줄 아는지를 묻는 문제다.
</pre>

접근 방법 : 

<pre>
해당 문제에서 제공되는 weights 배열의 길이는 최대 10만이므로
O(N^2)의 시간복잡도를 갖는 알고리즘으로는 문제를 해결할 수 없다.

즉, O(N) 또는 O(NlogN)등의 시간복잡도를 갖는 알고리즘으로 문제를 해결해야 하는데,
어떤 특정한 연속된 구간에 대하여, 특정한 값과 동일한 값이 몇 개나 존재하는 지를 쉽게 파악하는 방법은
upperbound( )와 lowerbound( )를 활용하는 것이며 이는 O(logN)의 시간 복잡도를 갖는다.

upperbound( )란 특정한 배열의 연속된 구간에서, 특정한 값 V보다 큰 값이 처음 나타나는 위치를 찾아내는 알고리즘이다.
lowerbound( )란 특정한 배열의 연속된 구간에서, 특정한 값 V보다 크거나 같은 값이 처음 나타나는 위치를 찾아내는 알고리즘이다.

여기서 upperbound( )의 결과에서 lowerbound( )의 결과를 빼면 V와 동일한 정수의 개수를 구해낼 수 있다.
다만, 특정한 배열은 반드시 오름차순 정렬이 되어있어야 한다.

시소에는 2, 3, 4m 지점에 앉을 수 있는데, 중복 순열의 개수를 구해보면
2:2, 2:3, 2:4, 3:2, 3:3, 3:4, 4:2, 4:3, 4:4와 같이 총 3^2 = 9개의 비율을 구할 수 있다.

이때 해당 비율들을 약분하고, 중복되는 비율을 제거해보면
1:1, 1:2, 2:1, 1:3, 3:1, 1:4, 4:1 비율을 얻어낼 수 있다.

그러나, weights배열을 오름차순 정렬하여 upperbound와 lowerbound를 구하므로
탐색의 기준이 될 몸무게는, 자신의 오른쪽 몸무게들보다 작거나 같음이 항상 보장되어있다.
따라서 1:2, 1:3, 1:4 비율은 굳이 탐색할 필요가 없다.

왜냐하면 탐색의 기준이 될 몸무게가 M이며, 그보다 오른쪽에 존재하는 몸무게를 N이라고 했을때
이미 오름차순 정렬로 M < N이 보장되어 있으므로 M < 2 * N또한 항상 보장되므로,
절대로 M == 2 * N이 되는 경우는 존재하지 않는다. 
따라서 기준이 될 몸무게에 곱할 가중치가 더 크거나 같을 때의 비율만 고려하면 된다.
</pre>

풀이 순서 : 

<pre>
1. 탐색할 기준이 될 몸무게를 선정한다.

2. 기준 몸무게의 오른쪽에 위치한 몸무게들에 대하여, 기준 몸무게와 오른쪽에 위치한 몸무게들에 가중치 비율을 곱하고
   upperbound( ) - lowerbound( )값을 구하여 answer에 누적하여 더한다.
</pre>

문제 풀이 결과 : 

![image](https://user-images.githubusercontent.com/83106564/219684493-69f3f19b-24b4-4aa8-b2de-9b83fe24504f.png)