### PR TITLE
[PGS] [BFS] [아이템 줍기]

### DIFF
--- a/PGS/BFS/아이템-줍기/Blanc_et_Noir/Solution.java
+++ b/PGS/BFS/아이템-줍기/Blanc_et_Noir/Solution.java
@@ -1,0 +1,109 @@
+//https://school.programmers.co.kr/learn/courses/30/lessons/87694
+
+import java.util.*;
+
+//y, x좌표 및 이동하는데 필요한 비용을 저장할 노드 클래스
+class Node{
+    int y, x, c;
+    Node(int y, int x, int c){
+        this.y=y;
+        this.x=x;
+        this.c=c;
+    }
+}
+
+class Solution {
+	//각 모서리의 y, x좌표를 입력받아 2차원 배열에 사각형을 채워넣는 메소드
+    public void paint(int[][] arr, int[] rectangle){
+        int ldx = rectangle[0]*2;
+        int ldy = rectangle[1]*2;
+        int rux = rectangle[2]*2;
+        int ruy = rectangle[3]*2;
+        
+        for(int i=ldy; i<=ruy; i++){
+            for(int j=ldx; j<=rux;j++){
+                arr[i][j]=1;
+            }
+        }
+    }
+    
+    //각 모서리의 y, x좌표를 입력 받아 해당 사각형의 내부를 제거하는 메소드
+    public void remove(int[][] arr, int[] rectangle){
+        int ldx = rectangle[0]*2;
+        int ldy = rectangle[1]*2;
+        int rux = rectangle[2]*2;
+        int ruy = rectangle[3]*2;
+        
+        for(int i=ldy+1; i<ruy; i++){
+            for(int j=ldx+1; j<rux;j++){
+                arr[i][j]=0;
+            }
+        }
+    }
+    
+    //BFS탐색시 y, x좌표가 배열 범위를 벗어나는지 확인하는 메소드
+    public boolean isInRange(int[][] arr, int y, int x){
+        if(y>=0&&y<arr.length&&x>=0&&x<arr[0].length){
+            return true;
+        }
+        return false;
+    }
+    
+    //sy, sx위치에서 시작하여 ey, ex로 이동하는데 필요한 최소 비용 / 2를 리턴하는 메소드
+    public int BFS(int[][] arr, int sy, int sx, int ey, int ex){
+        int result = 0;
+        
+        //BFS에 사용할 큐 선언
+        Queue<Node> q = new LinkedList<Node>();
+        q.add(new Node(sy,sx,0));
+        
+        int[][] dist = new int[][]{{-1,0},{1,0},{0,-1},{0,1}};
+        
+        boolean[][] v = new boolean[arr.length][arr[0].length];
+        v[sy][sx] = true;
+        
+        while(!q.isEmpty()){
+            Node n = q.poll();
+            
+            //아이템을 주웠다면
+            if(n.y==ey&&n.x==ex){
+            	//좌표를 2배 했으므로, 비용은 그 절반이 되어야 함
+                result = n.c / 2;
+                break;
+            }
+            
+            for(int i=0;i<dist.length;i++){
+                int y = n.y + dist[i][0];
+                int x = n.x + dist[i][1];
+                
+                //다음에 이동할 테두리가 아직 방문하지 않았고, 맵을 벗어나지도 않는다면
+                if(isInRange(arr,y,x)&&!v[y][x]&&arr[y][x]==1){
+                	//해당 위치를 탐색할 수 있도록 큐에 추가하고 방문처리함
+                    q.add(new Node(y,x,n.c+1));
+                    v[y][x]=true;
+                }
+            }
+        }
+        
+        //최소 비용을 리턴함
+        return result;
+    }
+    
+    public int solution(int[][] rectangle, int characterX, int characterY, int itemX, int itemY) {        
+        int[][] arr = new int[50*2+1][50*2+1];
+        
+        //주어진 사각형을 arr2차원 배열에 그림
+        for(int i=0; i<rectangle.length;i++){
+        	//좌표를 2배로 확대하여 사각형을 채워 넣음
+            paint(arr,rectangle[i]);
+        }
+        
+        //주어진 사각형의 내부를 제거함
+        for(int i=0; i<rectangle.length;i++){
+            remove(arr,rectangle[i]);
+        }
+        
+        //좌표가 2배가 되었으므로, 시작 및 종료 좌표도 2배가 되어야 함
+        return BFS(arr,characterY*2, characterX*2, itemY*2, itemX*2);
+    }
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://school.programmers.co.kr/learn/courses/30/lessons/87694)


문제 요구사항 : 

<pre>
해당 문제는 BFS탐색 알고리즘을 알고 있는지,
BFS탐색을 하기 위해 맵 좌표를 2배로 확장하는 방법을 아는 지,
주어진 사각형 도형의 테두리만을 추출해낼 줄 아는 지를 묻는 문제다.
</pre>

접근 방법 : 

<pre>
일반적인 BFS탐색 문제와 달리, 해당 문제는 맵의 좌표를 2배로 확장할 필요가 있다.
좌표를 2배로 확장하지 않으면, 제대로 된 최단 경로를 찾지 못하는 문제가 있기 때문이다.

좌표를 2배로 확장하는 방법은 간단하다.
주어진 좌표가 x1, y1, x2, y2라면 2*x1, 2*y1, 2*x2, 2*y2로 처리하여 맵을 채우면 된다.

테두리만을 추출하는 방법도 간단하다.
우선 모든 사각형을 내부까지 포함하여 맵에 까맣게 칠한다.
그 후에, 모든 사각형의 내부를 맵에서 제거하면 된다.

그렇게 추출된 테두리를 따라 BFS탐색을 수행하며 아이템의 위치에 도달하게 되면
그때 사용한 비용의 절반을 정답으로 처리한다.
왜냐하면 좌표가 2배로 확장되었기 때문에, 비용은 절반으로 다시 줄여야 하기 때문이다.
</pre>

풀이 순서 : 

<pre>
1. 맵의 좌표를 2배로 확장한다.

2. 모든 사각형을 내부까지 까맣게 맵에 칠한다.

3. 모든 사각형의 내부를 맵에서 제거하여 테두리만을 얻어낸다.

4. 테두리를 따라 아이템을 줍도록 BFS탐색을 수행하되
   아이템의 위치에 도달하면 그때 사용한 비용/2를 정답으로 출력한다.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/222968107-e4f32300-ba3e-4245-ac84-7726865fa9e1.png)