### PR TITLE
[GRM] [BFS] [알파벳 트리 장난감]

### DIFF
--- a/GRM/BFS/알파벳-트리-장난감/Blanc_et_Noir/Main.java
+++ b/GRM/BFS/알파벳-트리-장난감/Blanc_et_Noir/Main.java
@@ -1,0 +1,112 @@
+import java.io.*;
+import java.util.*;
+
+//트리의 level, 해당 레벨에서의 index, 여태까지 얻은 점수 point를 저장하는 노드 클래스
+class Node implements Comparable<Node>{
+	final int val;
+	int level, idx, point;
+	boolean flag;
+	
+	//노드 클래스는 flag변수가 true이냐 false이냐에 따라 우선순위큐에서 다르게 정렬됨
+	Node(int level, int idx, int point, boolean flag){
+		this.level = level;
+		this.idx = idx;
+		this.point = point;
+		if(flag){
+			this.val = 1;
+		}else{
+			this.val = -1;
+		}
+	}
+	
+	//flag가 true라면 점수가 더 큰 노드가 먼저 반환되며, 아니라면 더 작은 노드가 먼저 반환됨
+	//점수가 동일하다면 flag가 true라면 레벨이 더 작은 노드가 먼저 반환되며, false라면 레벨이 더 큰 노드가 먼저 반환됨
+	@Override
+	public int compareTo(Node n){
+		if(this.point>n.point){
+			return -1*val;
+		}else if(this.point<n.point){
+			return 1*val;
+		}else{
+			if(this.level<n.level){
+				return -1*val;
+			}else if(this.level>n.level){
+				return 1*val;
+			}else{
+				return 0;
+			}
+		}
+	}
+}
+
+class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	
+	//어떤 인덱스에 대해, 자식들의 인덱스를 구하는 메소드
+	public static int[] getChildren(int idx){
+		return new int[]{idx*2,idx*2+1};
+	}
+	
+	//어떤 문자열을 점수로 변환하는 메소드
+	public static int getPoint(char ch){
+		return ch-'A'+1;
+	}
+	
+	//flag가 true라면 가장 큰 점수를, 아니라면 가장 작은 점수를 구하는 BFS메소드
+	public static int BFS(char[][] arr, boolean flag){
+		//BFS탐색에 사용할 우선순위 큐
+		PriorityQueue<Node> pq = new PriorityQueue<Node>();
+		
+		//마지막 level까지 도달했을때의 점수를 오름차순 또는 내림차순 정렬하여 저장할 우선순위 큐
+		PriorityQueue<Node> rq = new PriorityQueue<Node>();;
+		
+		//flag가 true라면 점수가 큰 순서대로 정렬되며
+		//flag가 false라면 점수가 작은 순서대로 정렬됨
+		pq.add(new Node(0,0,getPoint(arr[0][0]),flag));
+		
+		while(!pq.isEmpty()){
+			Node n = pq.poll();
+			
+			int level = n.level;
+			int point = n.point;
+			int idx = n.idx;
+
+			//만약 트리의 마지막 level까지 모두 탐색했다면
+			if(level==arr.length-1){
+				//그때의 노드를 결과 우선순위 큐에 저장함
+				rq.add(n);
+				continue;
+			}
+			
+			//자식들의 인덱스를 얻음
+			int[] children = getChildren(idx);
+			
+			//두 자식들을 선택했을때의 점수를 계산하여 우선순위 큐에 추가함
+			pq.add(new Node(level+1,children[0],point+getPoint(arr[level+1][children[0]]),flag));
+			pq.add(new Node(level+1,children[1],point+getPoint(arr[level+1][children[1]]),flag));
+		}
+		
+		//결과 큐의 가장 맨 앞의 점수가 구하고자하는 값임
+		return rq.peek().point;
+	}
+	
+	public static void main(String[] args) throws Exception {
+		final int N = Integer.parseInt(br.readLine());
+		
+		//트리의 정보를 저장할 배열선언
+		char[][] arr = new char[N][1<<(N-1)];
+		
+		//문자를 입력받음
+		for(int i=0;i<N;i++){
+			arr[i] = br.readLine().toCharArray();
+		}
+		
+		//가장 작을때의 점수와 클 때의 점수를 출력함
+		bw.write(BFS(arr, false)+"\n");
+		bw.write(BFS(arr, true)+"\n");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://level.goorm.io/exam/49093/%EC%95%8C%ED%8C%8C%EB%B2%B3-%ED%8A%B8%EB%A6%AC-%EC%9E%A5%EB%82%9C%EA%B0%90/quiz/1)


문제 요구사항 : 

<pre>
해당 문제는 BFS 또는 DFS를 활용한 완전 탐색을 구현할 줄 아는 지를 묻는 문제다.
</pre>

접근 방법 : 

<pre>
완전 탐색은 보통 DFS를 사용하는 것이 일반적이나, 필자는 BFS를 활용하였다.

어떤 노드의 번호가 n이라면, 두 자식 노드의 번호는 n*2와 n*2+1이다.
이러한 공식을 활용한다면 굳이 이진 트리를 구성하지 않고 배열로도 트리를 구현할 수 있다.

어떤 노드의 번호가 n일 때,  두 자식노드 n*2, n*2+1를 선택하여 얻을 수 있는 점수를 누적하여 구하고,
계속해서 자식노드를 탐색해 나가면서, 리프노드에 도달할 경우 최종 점수를 배열에 저장해둔다.
그리고 그 배열에 저장된 점수 중에서 가장 큰 점수를 출력하면 된다.
</pre>

풀이 순서 : 

<pre>
1. 현재 노드의 번호 n에 대하여, n*2, n*2+1을 각각 선택했을 때의 점수를
   누적하여 더한 뒤에 그 정보를 큐에 추가한다.

2. 큐에서 노드를 하나 꺼낸 뒤, 1의 과정을 반복한다.

3. 현재 노드가 리프 노드인 경우, 여태까지 누적하여 더한 점수를 리스트에 저장한다.

4. BFS탐색이 종료된 이후, 리스트에 저장된 점수 중 가장 큰 점수를 출력한다.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/225655885-524bd814-eb46-45ca-ac80-a11943bd5f0f.png)