### PR TITLE
[GRM] [Segment-Tree] [잡초 제거]

### DIFF
--- a/GRM/Segment-Tree/잡초-제거/Blanc_et_Noir/Main.java
+++ b/GRM/Segment-Tree/잡초-제거/Blanc_et_Noir/Main.java
@@ -1,0 +1,123 @@
+//https://level.goorm.io/exam/51351/%EC%9E%A1%EC%B4%88-%EC%A0%9C%EA%B1%B0/quiz/1
+
+import java.io.*;
+import java.util.*;
+
+class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static int[] arr = null;
+	static int[] tree = null;
+	
+	//세그먼트 트리를 초기화하는 메소드
+	public static void init(int n, int s, int e){
+		//리프노드라면
+		if(s==e){
+			//세그먼트 트리의 노드에 값을 대입함
+			tree[n] = arr[s];
+		//아니라면
+		}else{
+			int m = (s+e)/2;
+			//세그먼트 트리의 두 자식노드에 대하여 재귀적으로 초기화를 수행함
+			init(n*2,s,m);
+			init(n*2+1,m+1,e);
+			
+			//초기화된 두 자식노드의 결과를 병합함
+			tree[n] = tree[n*2] + tree[n*2+1];
+		}
+	}
+	
+	//세그먼트 트리의 l, r구간에 대하여 구간합을 구하는 메소드
+	public static int query(int n, int s, int e, int l, int r){
+		//현재 탐색중인 구간이 탐색하고자 하는 구간을 완전히 벗어난 경우
+		if(s>r||e<l){
+			//0을 리턴하여 결과에 영향이 없도록 함
+			return 0;
+		//현재 탐색중인 구간이 탐색하고자 하는 구간에 완전히 포함된 경우
+		}else if(l<=s&&e<=r){
+			//그때의 세그먼트 트리의 값을 리턴함
+			return tree[n];
+		//구간이 걸치기만 한 경우
+		}else{
+			int m = (s+e)/2;
+			//두 자식노드에 대하여 재귀적으로 쿼리를 수행하고, 그 결과를 병합함
+			return query(n*2,s,m,l,r) + query(n*2+1,m+1,e,l,r);
+		}
+	}
+	
+	//idx에 해당하는 값을 v만큼 증가시키는 메소드
+	public static void update(int n, int s, int e, int idx, int v){
+		//idx가 현재 탐색중인 구간을 완전히 벗어난경우
+		if(idx>e||idx<s){
+			//즉시 종료함
+			return;
+		//리프노드라면
+		}else if(s==e){
+			//arr 배열과 세그먼트 트리의 값을 v증가시킴
+			arr[idx]+=v;
+			tree[n]+=v;
+			return;
+		//구간이 걸치기만 하는 경우
+		}else{
+			int m = (s+e)/2;
+			//두 자식노드에 대하여 재귀적으로 갱신을 수행함
+			update(n*2,s,m,idx,v);
+			update(n*2+1,m+1,e,idx,v);
+			
+			//두 자식노드의 값을 병합하여 부모노드의 값으로 설정함
+			tree[n] = tree[n*2] + tree[n*2+1];
+			return;
+		}
+	}
+	
+	public static void main(String[] args) throws Exception {
+		String[] temp = br.readLine().split(" ");
+		
+		int N = Integer.parseInt(temp[0]);
+		int Q = Integer.parseInt(temp[1]);
+		
+		//배열과 세그먼트 트리 선언
+		arr = new int[N];
+		tree = new int[4*N];
+		
+		temp = br.readLine().split(" ");
+		
+		for(int i=0;i<N;i++){
+			arr[i] = Integer.parseInt(temp[i]);
+		}
+		
+		//세그먼트 트리를 초기화함
+		init(1,0,N-1);
+		
+		//Q개의 쿼리를 수행함
+		for(int i=0;i<Q;i++){
+			temp = br.readLine().split(" ");
+			
+			//q, a, b를 각각 입력받음
+			int q = Integer.parseInt(temp[0]);
+			int a = Integer.parseInt(temp[1]);
+			int b = Integer.parseInt(temp[2]);
+			
+			switch(q){
+				//1번 쿼리라면
+				case 1:
+					//주어진 구간에 대하여 구간합을 출력함
+					bw.write(query(1,0,N-1,a-1,b-1)+"\n");
+					break;
+				//2번 쿼리라면
+				case 2:
+					//해당 인덱스의 값을 b증가시킴
+					update(1,0,N-1,a-1,b);
+					break;
+				//3번 쿼리라면
+				case 3:
+					//해당 인덱스의 값을 b감소시킴
+					update(1,0,N-1,a-1,-b);
+					break;
+			}
+		}
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://level.goorm.io/exam/51351/%EC%9E%A1%EC%B4%88-%EC%A0%9C%EA%B1%B0/quiz/1)


문제 요구사항 : 

<pre>
해당 문제는 세그먼트 트리를 구현할 줄 아는지, 활용할 줄 아는지를 묻는 문제다.
</pre>

접근 방법 : 

<pre>
해당 문제를 단순하게 배열과 반복문으로 문제를 해결한다면
배열의 크기가 최대 200000, 쿼리의 개수가 최대 200000이므로

O(N^2)의 시간복잡도를 갖는 알고리즘을 작성했을때 최악의 경우에는
200000 * 200000 번의 반복을 수행해야 한다는 문제가 발생한다.

따라서, 이 시간복잡도를 최소 O(NlogN)
또는 그 이하의 시간복잡도를 갖는 알고리즘을 떠올려야만 한다.

바로 이 문제와 같이 연속적인 구간에 대한 특정 값을 효율적으로 계산해야 하는 경우,
세그먼트 트리라는 자료구조를 활용하면 쉽게 해결할 수 있다.
이 세그먼트 트리를 활용하면 O(NlogN)의 시간복잡도를 갖게 된다.

세그먼트 트리는 재귀함수를 이용하여 구현하는 것이 일반적이며,
세그먼트 트리의 노드는 일반적인 트리와는 달리 특정한 연속 구간에 대한 값을 가지고 있다.

세그먼트 트리의 초기화는 아래와 같이 구현할 수 있다.
리프노드에 도달할 때 까지 재귀적으로 탐색을 진행하며,
리프노드에 도달했다면 세그먼트 트리의 해당 노드에 배열의 값을 대입한다.
그후 재귀적으로 두 리프노드의 값의 합을 부모 리프노드의 값으로 설정하는 것을 반복한다.

세그먼트 트리의 특정 노드를 갱신하는 기능 역시 초기화와 동일하게 구현하면 되는데,
대신 리프노드까지 탐색한 이후 배열의 값을 V만큼 증가 또는 감소시키고
부모 노드의 값을 다시 두 자식노드의 값의 합으로 갱신하는 것을 재귀적으로 반복한다.

세그먼트 트리에서 특정 구간의 값을 구하는 방법은 아래와 같이 구현할 수 있다.
1. 현재 탐색중인 구간이 탐색하고자 하는 구간을 완전히 벗어나는 경우, 0을 리턴한다.

2. 현재 탐색중인 구간이 탐색하고자 하는 구간에 살짝 걸치는 경우,
   현재 탐색 중인 구간을 절반으로 나누어 재귀적으로 탐색을 이어나간다.

3. 현재 탐색중인 구간이 탐색하고자 하는 구간을 완전히 포함하는 경우,
   해당 세그먼트 트리의 노드 값을 리턴한다.
</pre>

풀이 순서 : 

<pre>
1. 세그먼트 트리를 선언하고 초기화한다.

5. 전달 받은 쿼리가 1을 증가시키는 쿼리인지, 구간의 합을 구하는 쿼리인지에 따라 적절한 출력을 낸다.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/226257433-983dcb76-469a-41f4-9eab-86bde96228a3.png)