### PR TITLE
[GRM] [Disjoint-Set] [그룹 지정]

### DIFF
--- a/GRM/Disjoint-Set/Blanc_et_Noir/Main.java
+++ b/GRM/Disjoint-Set/Blanc_et_Noir/Main.java
@@ -1,0 +1,80 @@
+//https://level.goorm.io/exam/49052/%EA%B7%B8%EB%A3%B9-%EC%A7%80%EC%A0%95/quiz/1
+
+import java.io.*;
+import java.util.*;
+
+class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	
+	//idx 인덱스를 갖는 정점의 최상위 부모를 리턴하는 find 메소드
+	public static int find(int[] parents, int idx){
+		//최상위 부모가 자기 자신이라면
+		if(parents[idx]==idx){
+			//자기 자신을 리턴함
+			return idx;
+		//최상위 부모가 자기 자신이 아니라면
+		}else{
+			//자신의 부모에 대하여 재귀적으로 부모를 구하고
+			//자신의 조부모를 자신의 부모로 설정함
+			return parents[idx] = find(parents,parents[idx]);
+		}
+	}
+	
+	//두 정점 idx1, idx2를 하나의 그룹으로 묶는 union 메소드
+	public static void union(int[] parents, int idx1, int idx2){
+		int parent1 = find(parents,idx1);
+		int parent2 = find(parents,idx2);
+		
+		//최상위 부모가 동일하다면
+		if(parent1==parent2){
+			//이미 두 정점은 같은 그룹에 속하는 것임
+			return;
+		//최상위 부모가 다르다면
+		}else{
+			//두 최상위 부모중 더 작은 최상위 부모가 더 큰 최상위 부모의 부모가 되도록 함
+			if(parent1<parent2){
+				parents[parent2] = parent1;
+			}else{
+				parents[parent1] = parent2;
+			}
+		}		
+	}
+	
+	public static void main(String[] args) throws Exception {
+		String[] temp = br.readLine().split(" ");
+		
+		final int N = Integer.parseInt(temp[0]);
+		final int M = Integer.parseInt(temp[1]);
+		int[] parents = new int[N];
+		
+		//최상위 부모를 자기자신으로 초기화함
+		for(int i=0;i<parents.length;i++){
+			parents[i]=i;
+		}
+		
+		//두 정점을 입력 받고, 그 정점을 하나의 그룹으로 묶음
+		for(int i=0;i<M;i++){
+			temp = br.readLine().split(" ");
+			int a = Integer.parseInt(temp[0])-1;
+			int b = Integer.parseInt(temp[1])-1;
+			
+			union(parents,a,b);
+		}
+		
+		//중복없이 최상위 부모 번호를 저장할 set선언
+		HashSet<Integer> set = new HashSet<Integer>();
+		
+		//최상위 부모가 동일하다면 동일한 그룹에 속하는 것임
+		//따라서, 최상위 부모를 중복없이 카운트 해야 하므로 set에 최상위 부모를 저장함
+		for(int i=0;i<parents.length;i++){
+			set.add(find(parents,i));
+		}
+		
+		//set의 크기가 곧 분리집합의 개수임
+		bw.write(set.size()+"\n");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://level.goorm.io/exam/49052/%EA%B7%B8%EB%A3%B9-%EC%A7%80%EC%A0%95/quiz/1)


문제 요구사항 : 

<pre>
해당 문제는 Union/Find 알고리즘을 알고 있는지
이를 활용하여 Disjoint Set 자료구조를 구현할 줄 아는 지를 묻는 문제다.
</pre>

접근 방법 : 

<pre>
Disjoint Set이라는 자료구조는 보편적으로 분리집합이라고 지칭되는 경우가 많다.
또는 서로소 집합이라고 지칭되기도 하는데, 이는 두 개 이상의 집합 간의 공통 원소가 없는 집합들을 말한다.
한 명의 사람은 단 하나의 그룹에만 포함될 수 있으므로, 분리집합이라고 볼 수 있다.

Find 알고리즘은 특정 노드에 대하여 최상위 부모가 누구인지를 찾는 알고리즘이다.
이는 재귀적으로 자신의 직계 부모에 대한 Find 알고리즘을 수행함으로써 쉽게 구현할 수 있다.
모든 노드들의 초기의 최상위 부모는 자기 자신이 되도록 설정해야한다.

Union 알고리즘은 두 노드를 같은 그룹으로 묶는 알고리즘이다.
두 노드가 같은 그룹이 되기 위해서는, 두 노드의 최상위 부모가 동일하기만 하면 된다.
두 노드의 최상위 부모를 구하고, 둘 중 더 작은 번호를 갖는 최상위 부모가,
다른 최상위 부모의 부모가 되도록 한다면 최종적으로 같은 그룹에 속하도록 만들 수 있다.

그룹의 총 개수는 서로 다른 최상위 부모의 수와 동일하다.
</pre>

풀이 순서 : 

<pre>
1. 모든 노드의 최상위 부모를 자기 자신으로 초기화한다.

2. 같은 그룹으로 지정해야 할 사람의 최상위 부모를 얻는다.
   이는 위에서 설명한 Find 알고리즘을 수행하면 된다.

3. 두 노드의 최상위 부모가 다르다면, 같은 그룹이 아닌 것이므로 서로를 같은 그룹으로 지정한다.
   이는 위에서 설명한 Union 알고리즘을 수행하면 된다.

4. 서로 다른 최상위 부모의 수를 출력한다.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/226643421-f36a3493-cfe8-4f94-8a83-e9035157008d.png)