### PR TITLE
[GRM] [BFS] [징검다리 건너기]

### DIFF
--- a/GRM/BFS/징검다리-건너기/Blanc_et_Noir/Main.java
+++ b/GRM/BFS/징검다리-건너기/Blanc_et_Noir/Main.java
@@ -1,0 +1,89 @@
+//https://level.goorm.io/exam/49112/%EC%A7%95%EA%B2%80%EB%8B%A4%EB%A6%AC-%EA%B1%B4%EB%84%88%EA%B8%B0/quiz/1
+
+import java.io.*;
+import java.util.*;
+
+//현재 위치 idx, 독극물의 양 val을 저장할 노드 클래스 선언
+class Node{
+	int idx, val;
+	Node(int idx, int val){
+		this.idx = idx;
+		this.val = val;
+	}
+}
+
+class Main {
+	//주어진 독극물 배치에 대하여 최소 비용으로 끝에 도달하기 위한 비용을 구하는 메소드
+	public static int BFS(int[] arr){
+		//더 적은 독극물 양이 누적된 노드가 먼저 반환되며,
+		//동일하다면 더 오른쪽에 위치한 노드가 먼저 반환되도록 하는 우선순위 큐 선언
+		PriorityQueue<Node> pq = new PriorityQueue<Node>(new Comparator<Node>(){
+			@Override
+			public int compare(Node n1, Node n2){
+				if(n1.val<n2.val){
+					return -1;
+				}else if(n1.val>n2.val){
+					return 1;
+				}else{
+					if(n1.idx>n2.idx){
+						return -1;
+					}else if(n1.idx<n2.idx){
+						return 1;
+					}else{
+						return 0;
+					}
+				}
+			}
+		});
+		
+		//시작 위치는 -1, 독극물의 양은 0으로 처리하고 큐에 추가함
+		pq.add(new Node(-1,0));
+		
+		int[] v = new int[arr.length];
+		
+		//방문 배열을 모두 MAX_VALUE로 초기화
+		for(int i=0;i<v.length;i++){
+			v[i] = Integer.MAX_VALUE;
+		}
+		
+		int answer = 0;
+		
+		while(!pq.isEmpty()){
+			Node n = pq.poll();
+			
+			//만약 3칸이내에 목표 지점이 있다면
+			if(n.idx >= arr.length-3){
+				//독극물을 더 밟을 필요가 없으므로 그때의 독극물을 리턴함
+				answer = n.val;
+				break;
+			}
+			
+			//현재 상태에 대하여, 1,2,3칸을 각각 움직여봄
+			for(int i=1;i<=3;i++){
+				//그렇게 움직였을때의 독극물의 양이 기존에 기록해둔 양보다 적다면
+				if(n.idx+i<arr.length&&n.val+arr[n.idx+i]<v[n.idx+i]){
+					//해당 위치에 방문하고 큐에 정보를 추가함
+					pq.add(new Node(n.idx+i,n.val+arr[n.idx+i]));
+					v[n.idx+i] = n.val + arr[n.idx+i];
+				}
+			}
+		}
+		return answer;
+	}
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		final int N = Integer.parseInt(br.readLine());
+		int[] arr = new int[N];
+		
+		String[] temp = br.readLine().split(" ");
+		
+		//독극물의 양을 입력받음
+		for(int i=0;i<N;i++){
+			arr[i] = Integer.parseInt(temp[i]);
+		}
+		
+		System.out.println(BFS(arr));
+		
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://level.goorm.io/exam/49112/%EC%A7%95%EA%B2%80%EB%8B%A4%EB%A6%AC-%EA%B1%B4%EB%84%88%EA%B8%B0/quiz/1)


문제 요구사항 : 

<pre>
해당 문제는 BFS 탐색 알고리즘을 구현할 줄 아는지를 묻는 문제다.
</pre>

접근 방법 : 

<pre>
일반적인 BFS 탐색 문제의 경우, 방문 배열을 보통 boolean의 형태로 구성하는 경우가 많지만,
해당 문제는 최소한의 비용으로 목적지에 도달하는 것을 구해야 하므로,
방문 배열은 boolean이 아닌 int의 형태가 되어야 한다.

즉, 해당 문제는 재방문을 반드시 허용해야 하는 BFS 탐색 문제다.

게다가, 일반적인 큐 대신에 더 적은 비용을 가진 노드의 정보가 먼저 반환되도록 하는 우선순위 큐를 사용하여
BFS 탐색 알고리즘을 구현해야만 문제를 해결할 수 있다.

i에 도달하기 위해 기존에 v1만큼의 비용을 사용했을 때,
이번에 v2의 비용(단, v2 < v1이어야 함)으로 i에 도달하고자 한다면, 재방문을 허용해야 한다.

일반적인 큐가 아니라 우선순위 큐를 사용해야 하는 이유는,
아무리 int[ ] 형태의 방문 배열을 사용하여 더 적은 비용을 소모 해야만 재방문을 허용한다고 하더라도
어떤 노드가 목적지에 도달했을 때 그것이 바로 정답임을 보장할 수는 없기 때문이다.
</pre>

풀이 순서 : 

<pre>
1. 배열에 정보를 입력 받는다.

2. 우선순위 큐를 활용하여 BFS 탐색을 수행한다.

3. 방문 배열을 MAX_VALUE로 초기화한다.

4. 이동하고자 하는 위치에 도달하기 위해 기존에 소모한 비용보다, 더 적은 비용으로 도달할 수 있다면
   재방문을 허용하고 BFS탐색을 진행한다. 

5. 어떤 노드가 목적지에 도달했을 경우 그 즉시 BFS탐색을 종료하고, 그때 소모한 비용을 정답으로 출력한다.
</pre>

문제 풀이 결과 : 성공

![image](https://user-images.githubusercontent.com/83106564/227560680-4ed483dc-2cbb-4607-b202-838ca29f271d.png)