### PR TITLE
[BOJ] [BFS] [4179] [불!]

### DIFF
--- a/BOJ/BFS/4179/Blanc_et_Noir/Main.java
+++ b/BOJ/BFS/4179/Blanc_et_Noir/Main.java
@@ -1,0 +1,93 @@
+//https://www.acmicpc.net/problem/4179
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.LinkedList;
+import java.util.Queue;
+
+class Node{
+	//y좌표, x좌표, 시간
+	int y, x, c;
+	//불인지 사람인지 구분할 변수
+	char k;
+	
+	Node(int y, int x, int c, char k){
+		this.y = y;
+		this.x = x;
+		this.c = c;
+		this.k = k;
+	}
+}
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	
+	public static void main(String[] args) throws IOException {
+		String[] input = br.readLine().split(" ");
+		String result = "IMPOSSIBLE";
+		
+		final int R = Integer.parseInt(input[0]);
+		final int C = Integer.parseInt(input[1]);
+		char[][] map = new char[R][C];
+		boolean[][] v = new boolean[R][C];
+		int[][] dir = {{-1,0},{1,0},{0,-1},{0,1}};
+		
+		Queue<Node> q = new LinkedList<Node>();
+		
+		Node node = null;
+		
+		for(int i=0; i<R; i++) {
+			map[i] = br.readLine().toCharArray();
+			
+			for(int j=0; j<C; j++) {				
+				if(map[i][j]=='F') {
+					//불의 좌표는 미리 큐에 추가함
+					//불이 먼저 이동할 수 있도록 하기 위함
+					q.add(new Node(i,j,1, 'F'));
+					v[i][j] = true;
+				}else if(map[i][j]=='J') {
+					node = new Node(i,j,1, 'J');
+					v[i][j] = true;
+				}
+			}
+		}
+		
+		//사람이 불보다 나중에 이동할 수 있도록 처리함
+		q.add(node);
+		
+		while(!q.isEmpty()) {
+			Node n = q.poll();
+			
+			//가장자리에 사람이 도달했을경우 종료
+			if(n.k=='J'&&(n.y==0||n.y==R-1||n.x==0||n.x==C-1)) {
+				result = n.c+"";
+				break;
+			}
+			
+			for(int i=0;i<dir.length;i++) {
+				int y = n.y + dir[i][0];
+				int x = n.x + dir[i][1];
+				
+				if(y<0||y>=R||x<0||x>=C) {
+					continue;
+				}
+				
+				//해당 공간에 방문한 적이 없으면 방문함
+				if(map[y][x]=='.'&&!v[y][x]) {
+					v[y][x] = true;
+					q.add(new Node(y,x,n.c+1, n.k));
+				}
+			}
+		}
+		
+		bw.write(result+"\n");
+		bw.flush();
+		br.close();
+		bw.close();
+		
+	}
+}


### PR DESCRIPTION
Source URL : [문제 URL](https://www.acmicpc.net/problem/4179)


문제 요구사항 : 

```
BFS 탐색을 활용하여 좌표 탐색을 수행할 줄 아는 지를 묻는 문제다.
```


접근 방법 : 

```
방법 1)

1. 불에 대한 BFS 탐색만을 먼저 수행한 후, 방문 배열에 방문 시각을 기록한다.

2. 그 후에 지훈이에 대한 BFS 탐색만을 수행할 때,
   자신의 방문 배열과 불의 방문 배열을 모두 고려하여 방문 여부를 결정한다.
   불이 자신보다 먼저 그 위치에 방문 했었다면 방문하지 않는다.



방법 2)

1. 불에 대한 시작 좌표를 모두 큐에 추가하고 나서야 지훈이의 좌표를 큐에 추가한다.

2. 이렇게 되면, 불은 같은 시각에 지훈이보다 먼저 방문 여부를 결정할 수 있게 되므로
   지훈이는 불과 방문 배열을 공유하여 사용할 수 있다는 장점이 있다.

```


풀이 순서 : 

```
필자는 방법 2)를 선택하여 해결하였다.

1. 지도 정보를 입력 받는다.
   불의 좌표는 지도 정보를 입력 받음과 동시에 큐에 추가하고 방문 처리한다.
   지훈이의 좌표는 임시로 기록만 해두고, 나중에 큐에 추가하고 방문 처리한다.

2. 지훈이가 가장자리에 도달할 때 까지 BFS 탐색을 수행한다.
   이때 방문 배열은 불의 방문 배열과 같은 것을 사용한다.

3. 지훈이가 탈출 할 수 없다면 IMPOSSIBLE를 출력하고
   탈출 한다면 탈출에 소요된 시간을 출력한다.
```


문제 풀이 결과 : 

![image](https://github.com/user-attachments/assets/874c5939-93ed-46f3-b9d0-48afca8d6a15)